### PR TITLE
Combine apt-get update and install calls

### DIFF
--- a/cmgr/challenge_types.go
+++ b/cmgr/challenge_types.go
@@ -50,8 +50,9 @@ const flaskDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-pip
 RUN pip3 install flask
 RUN groupadd -r flask && useradd -r -d /app -g flask flask
 
@@ -61,7 +62,7 @@ ENV FLASK_RUN_PORT=5000
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
@@ -94,14 +95,14 @@ const phpDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install php
+RUN apt-get update && apt-get install -y \
+    php
 RUN groupadd -r php && useradd -r -d /app -g php php
 
 # End of shared layers for all php challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY --chown=php:php . /app
 
@@ -135,7 +136,7 @@ RUN groupadd -r app && useradd -r -d /app -g app app
 # End of shared layers for all node challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY --chown=app:app . /app
 
@@ -170,11 +171,12 @@ const solverDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-pip
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
@@ -189,13 +191,13 @@ const staticMakeDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential
 RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY . /app
 WORKDIR /app
@@ -217,16 +219,16 @@ const remoteMakeDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install build-essential
-RUN apt-get -y install socat
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    socat
 
 RUN groupadd -r app && useradd -r -d /app -g app app
 RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY . /app
 WORKDIR /app
@@ -255,8 +257,8 @@ const serviceMakeDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential
 
 RUN groupadd -r app && useradd -r -d /app -g app app
 RUN install -d -m 0700 /challenge
@@ -265,7 +267,7 @@ ENV PORT=5000
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY . /app
 WORKDIR /app
@@ -294,15 +296,16 @@ const staticPybuildDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
-RUN apt-get -y install gcc-multilib
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-multilib \
+    python3-pip
 RUN pip3 install ninja2
 RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
@@ -448,9 +451,10 @@ const servicePybuildDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
-RUN apt-get -y install gcc-multilib
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-multilib \
+    python3-pip
 RUN pip3 install ninja2
 
 RUN groupadd -r app && useradd -r -d /app -g app app
@@ -460,7 +464,7 @@ ENV PORT=5000
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
@@ -611,10 +615,11 @@ const remotePybuildDockerfile = `
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
-RUN apt-get -y install gcc-multilib
-RUN apt-get -y install socat
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-multilib \
+    python3-pip \
+    socat
 RUN pip3 install ninja2
 
 RUN groupadd -r app && useradd -r -d /app -g app app
@@ -622,7 +627,7 @@ RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi

--- a/cmgr/dockerfiles/flask.Dockerfile
+++ b/cmgr/dockerfiles/flask.Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-pip
 RUN pip3 install flask
 RUN groupadd -r flask && useradd -r -d /app -g flask flask
 
@@ -12,7 +13,7 @@ ENV FLASK_RUN_PORT=5000
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi

--- a/cmgr/dockerfiles/node.Dockerfile
+++ b/cmgr/dockerfiles/node.Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -r app && useradd -r -d /app -g app app
 # End of shared layers for all node challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY --chown=app:app . /app
 

--- a/cmgr/dockerfiles/php.Dockerfile
+++ b/cmgr/dockerfiles/php.Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install php
+RUN apt-get update && apt-get install -y \
+    php
 RUN groupadd -r php && useradd -r -d /app -g php php
 
 # End of shared layers for all php challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY --chown=php:php . /app
 

--- a/cmgr/dockerfiles/remote-make.Dockerfile
+++ b/cmgr/dockerfiles/remote-make.Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install build-essential
-RUN apt-get -y install socat
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    socat
 
 RUN groupadd -r app && useradd -r -d /app -g app app
 RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY . /app
 WORKDIR /app

--- a/cmgr/dockerfiles/remote-pybuild.Dockerfile
+++ b/cmgr/dockerfiles/remote-pybuild.Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
-RUN apt-get -y install gcc-multilib
-RUN apt-get -y install socat
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-multilib \
+    python3-pip \
+    socat
 RUN pip3 install ninja2
 
 RUN groupadd -r app && useradd -r -d /app -g app app
@@ -12,7 +13,7 @@ RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi

--- a/cmgr/dockerfiles/service-make.Dockerfile
+++ b/cmgr/dockerfiles/service-make.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential
 
 RUN groupadd -r app && useradd -r -d /app -g app app
 RUN install -d -m 0700 /challenge
@@ -11,7 +11,7 @@ ENV PORT=5000
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY . /app
 WORKDIR /app

--- a/cmgr/dockerfiles/service-pybuild.Dockerfile
+++ b/cmgr/dockerfiles/service-pybuild.Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
-RUN apt-get -y install gcc-multilib
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-multilib \
+    python3-pip
 RUN pip3 install ninja2
 
 RUN groupadd -r app && useradd -r -d /app -g app app
@@ -13,7 +14,7 @@ ENV PORT=5000
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi

--- a/cmgr/dockerfiles/solver.Dockerfile
+++ b/cmgr/dockerfiles/solver.Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-pip
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi

--- a/cmgr/dockerfiles/static-make.Dockerfile
+++ b/cmgr/dockerfiles/static-make.Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install build-essential
+RUN apt-get update && apt-get install -y \
+    build-essential
 RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY . /app
 WORKDIR /app

--- a/cmgr/dockerfiles/static-pybuild.Dockerfile
+++ b/cmgr/dockerfiles/static-pybuild.Dockerfile
@@ -1,15 +1,16 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install python3-pip build-essential
-RUN apt-get -y install gcc-multilib
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-multilib \
+    python3-pip
 RUN pip3 install ninja2
 RUN install -d -m 0700 /challenge
 # End of shared layers for all flask challenges
 
 COPY Dockerfile packages.txt* ./
-RUN if [ -f packages.txt ]; then xargs -a packages.txt apt-get install -y; fi
+RUN if [ -f packages.txt ]; then apt-get update && xargs -a packages.txt apt-get install -y; fi
 
 COPY Dockerfile requirements.txt* ./
 RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi

--- a/examples/multi/Dockerfile
+++ b/examples/multi/Dockerfile
@@ -2,9 +2,9 @@
 
 FROM ubuntu:20.04 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y ssh
-RUN apt-get install -y python3
+RUN apt-get update && apt-get install -y \
+    python3 \
+    ssh
 
 RUN mkdir /challenge
 COPY finalize.py .
@@ -24,14 +24,14 @@ RUN python3 finalize.py
 ####################
 FROM ubuntu:20.04 AS work
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y ssh
+RUN apt-get update && apt-get install -y \
+    ssh \
+    sudo
 RUN mkdir -p /run/sshd
 
 RUN useradd -m -s /bin/bash asmith
 RUN useradd -m -s /bin/bash esmythe
 
-RUN apt-get install -y sudo
 COPY apt-get.sudoers /etc/sudoers.d/badsudo
 
 COPY --from=builder set-passwords.sh .
@@ -58,8 +58,8 @@ EXPOSE 22
 ###############################
 FROM ubuntu:20.04 AS randomDnsName
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y ssh
+RUN apt-get update && apt-get install -y \
+    ssh
 RUN mkdir -p /run/sshd
 
 RUN useradd -m -s /bin/bash alice


### PR DESCRIPTION
Builds will sometimes fail due to apt cache issues, since the `apt-get update` layer is essentially permanently cached. For example:

```shell
$ ../cmgr build cmgr/examples/binex101 0
# cmgr: [ERROR:  failed to build image: The command '/bin/sh -c apt-get -y install build-essential' returned a non-zero code: 100]
# error: failed to build image: The command '/bin/sh -c apt-get -y install build-essential' returned a non-zero code: 100
```

Extracting out and building just the first part of the Dockerfile shows the problem in this case:

```Dockerfile
FROM ubuntu:20.04
ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update
RUN apt-get -y install build-essential
RUN apt-get -y install socat
```

```shell
$ docker build -f test.Dockerfile .
# ...
# Get:83 http://archive.ubuntu.com/ubuntu focal/main amd64 libalgorithm-diff-xs-perl amd64 0.04-6 [11.3 kB]
# Get:84 http://archive.ubuntu.com/ubuntu focal/main amd64 libalgorithm-merge-perl all 0.08-3 [12.0 kB]
# Get:85 http://archive.ubuntu.com/ubuntu focal/main amd64 libfile-fcntllock-perl amd64 0.22-3build4 [33.1 kB]
# Get:86 http://archive.ubuntu.com/ubuntu focal/main amd64 libsasl2-modules amd64 2.1.27+dfsg-2 [49.1 kB]
# Get:87 http://archive.ubuntu.com/ubuntu focal/main amd64 manpages-dev all 5.05-1 [2266 kB]
# Fetched 53.6 MB in 10s (5257 kB/s)
# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_5.4.0-52.57_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap-common_2.4.49+dfsg-2ubuntu1.3_all.deb  404  Not Found [IP: 91.189.88.142 80]
# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap-2.4-2_2.4.49+dfsg-2ubuntu1.3_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
# E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
# The command '/bin/sh -c apt-get -y install build-essential' returned a non-zero code: 100
```

This PR groups all `apt-get update` and `apt-get install` calls to avoid outdated cache issues as described here: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get