### PR TITLE
Add fixes for per-artifact download access

### DIFF
--- a/cmd/cmgrd/main.go
+++ b/cmd/cmgrd/main.go
@@ -195,7 +195,8 @@ func (s state) challengeHandler(w http.ResponseWriter, r *http.Request) {
 func (s state) buildHandler(w http.ResponseWriter, r *http.Request) {
 	path := strings.Split(r.URL.Path, "/")
 	pathLen := len(path)
-	if path[pathLen-1] == "artifacts.tar.gz" {
+
+	if pathLen == 4 {
 		s.artifactsHandler(w, r)
 		return
 	}
@@ -259,12 +260,12 @@ func (s state) buildHandler(w http.ResponseWriter, r *http.Request) {
 func (s state) artifactsHandler(w http.ResponseWriter, r *http.Request) {
 	path := strings.Split(r.URL.Path, "/")
 	pathLen := len(path)
-	if pathLen < 3 || path[pathLen-3] != "builds" {
+	if pathLen < 4 || path[pathLen-3] != "builds" {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	buildInt, err := strconv.Atoi(path[pathLen-1])
+	buildInt, err := strconv.Atoi(path[pathLen-2])
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
@@ -306,7 +307,7 @@ func (s state) artifactsHandler(w http.ResponseWriter, r *http.Request) {
 	var h *tar.Header
 	for h, err = srcTar.Next(); err == nil; h, err = srcTar.Next() {
 		if h.Name == path[pathLen-1] {
-			io.Copy(w, f)
+			io.Copy(w, srcTar)
 			return
 		}
 	}


### PR DESCRIPTION
Makes a few small tweaks to fix things that prevented access to artifact downloads.

I think there may be a few other places where `if len(path) < n` checks might be off-by-one due to a leading empty string in the split path slice, but I was only really looking at `artifactsHandler` for this PR.