### PR TITLE
Add darwin and arm64 builds to release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,52 @@ on:
 name: Upload Release Asset
 
 jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Collect examples
+        run: |
+          tar czvf examples.tar.gz examples
+
+      - name: Upload Examples
+        id: upload-examples
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./examples.tar.gz
+          asset_name: examples.tar.gz
+          asset_content_type: application/octet-stream
   build:
-    name: Upload Release Asset
-    runs-on: ubuntu-20.04
+    name: Build Release Binaries
+    runs-on: ${{ matrix.os }}
+    needs: create-release
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macos-11
+        arch:
+          - amd64
+          - arm64
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -23,22 +66,19 @@ jobs:
         run: |
           go get -v -t -d ./...
           mkdir bin
-          go build -v -ldflags "-X github.com/ArmyCyberInstitute/cmgr/cmgr.version=`git describe --tags`" -o bin ./...
-          tar czvf examples.tar.gz examples
+          GOARCH=${arch} go build -v -ldflags "-X github.com/ArmyCyberInstitute/cmgr/cmgr.version=`git describe --tags`" -o bin ./...
           cp LICENSE bin/LICENSE
           cat NOTICE NOTICE.release > bin/NOTICE
           cd bin && tar czvf cmgr.tar.gz cmgr cmgrd LICENSE NOTICE
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          arch: ${{ matrix.arch }}
+
+      - name: Get OS/architecture suffix
+        id: suffix
+        run: |
+          echo "::set-output name=arch_suffix::`go version | cut -d ' ' -f 4,4 | cut -d '/' -f 1,1`_${arch}"
+        env:
+          arch: ${{ matrix.arch }}
 
       - name: Upload Binaries
         id: upload-binaries
@@ -46,18 +86,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: ./bin/cmgr.tar.gz
-          asset_name: cmgr.tar.gz
+          asset_name: cmgr_${{ steps.suffix.outputs.arch_suffix }}.tar.gz
           asset_content_type: application/octet-stream
 
-      - name: Upload Examples
-        id: upload-examples
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./examples.tar.gz
-          asset_name: examples.tar.gz
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
Expands the release build matrix to include executables for macOS and ARM platforms.

Part of the goal is to simplify the getting started process for challenge authors using Docker Desktop on macOS. This works fine, but previously required building from source.

- The utility of the `linux/arm64` build is perhaps limited, but it seemed maybe nice-to-have as a futureproofing measure. It could be [excluded](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-excluding-configurations-from-a-matrix) if you don't think it's worth having.
- I didn't actually test the `darwin/arm64` build because I don't have an M1 machine... 😔
- It would have been nice to do cross-compilation with `GOOS` alone but apparently this gets tricky when cgo is involved, so I just used the macOS runner.
- I considered adding macOS to the test workflow also, but that seemed
    1. Complicated, since the macOS Actions runners don't include Docker support
    2. Maybe unnecessary, since Docker Desktop runs a Linux VM anyway
- I didn't pursue a Windows build because in that case it seems easier to just install both Docker and cmgr inside WSL2, whereas on macOS the underlying Linux VM is not suitable for direct use.