### PR TITLE
Add container and network options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ can be enumerated with `cat /proc/sys/net/ipv4/ip_local_port_range` and adjusted
 with `sysctl`.  Some programs (e.g., `docker`) will need to be restarted after
 adjusting the kernel parameter.
 
+- *CMGR\_ENABLE\_DISK\_QUOTAS*: enables the [disk
+  quota](examples/markdown_challenges.md#container-options) container option when set. Disk quotas
+  are only functional when using the `overlay2` Docker storage driver and
+  [pquota-enabled](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsquota)
+  XFS backing storage. Otherwise, the creation of containers with disk quotas will fail at runtime.
+  When unset, any specified quotas are ignored.
+
 Additionally, we rely on the Docker SDK's ability to self-configure base off
 environment variables.  The documentation for those variables can be found at
 [https://docs.docker.com/engine/reference/commandline/cli/](https://docs.docker.com/engine/reference/commandline/cli/).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ with `sysctl`.  Some programs (e.g., `docker`) will need to be restarted after
 adjusting the kernel parameter.
 
 - *CMGR\_ENABLE\_DISK\_QUOTAS*: enables the [disk
-  quota](examples/markdown_challenges.md#container-options) container option when set. Disk quotas
+  quota](examples/markdown_challenges.md#challenge-options) container option when set. Disk quotas
   are only functional when using the `overlay2` Docker storage driver and
   [pquota-enabled](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsquota)
   XFS backing storage. Otherwise, the creation of containers with disk quotas will fail at runtime.

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -228,12 +228,16 @@ func (m *Manager) newInstance(build *BuildMetadata) (InstanceId, error) {
 		return 0, err
 	}
 
-	err = m.startNetwork(iMeta)
+	cMeta, err := m.GetChallengeMetadata(build.Challenge)
 	if err != nil {
 		return 0, err
 	}
 
-	err = m.startContainers(build, iMeta)
+	err = m.startNetwork(iMeta, cMeta.NetworkOptions)
+	if err != nil {
+		return 0, err
+	}
+
 	if err != nil {
 		// It is possible we are in a partially deployed state.  Make sure
 		// we are torn down, but ignore the returned error.

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -238,6 +238,7 @@ func (m *Manager) newInstance(build *BuildMetadata) (InstanceId, error) {
 		return 0, err
 	}
 
+	err = m.startContainers(build, iMeta, cMeta.ContainerOptions)
 	if err != nil {
 		// It is possible we are in a partially deployed state.  Make sure
 		// we are torn down, but ignore the returned error.

--- a/cmgr/api.go
+++ b/cmgr/api.go
@@ -233,12 +233,12 @@ func (m *Manager) newInstance(build *BuildMetadata) (InstanceId, error) {
 		return 0, err
 	}
 
-	err = m.startNetwork(iMeta, cMeta.NetworkOptions)
+	err = m.startNetwork(iMeta, cMeta.ChallengeOptions.NetworkOptions)
 	if err != nil {
 		return 0, err
 	}
 
-	err = m.startContainers(build, iMeta, cMeta.ContainerOptions)
+	err = m.startContainers(build, iMeta, cMeta.ChallengeOptions.Overrides)
 	if err != nil {
 		// It is possible we are in a partially deployed state.  Make sure
 		// we are torn down, but ignore the returned error.

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -162,7 +162,7 @@ const schemaQuery string = `
 		readonlyrootfs INTEGER NOT NULL CHECK(readonlyrootfs == 0 OR readonlyrootfs == 1),
 		droppedcaps TEXT NOT NULL,
 		nonewprivileges INTEGER NOT NULL CHECK(nonewprivileges == 0 OR nonewprivileges == 1),
-		storageopts TEXT NOT NULL,
+		diskquota TEXT NOT NULL,
 		cgroupparent TEXT NOT NULL,
 		FOREIGN KEY (challenge) REFERENCES challenges (id)
 			ON UPDATE CASCADE ON DELETE CASCADE

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -146,7 +146,7 @@ const schemaQuery string = `
 
 	CREATE TABLE IF NOT EXISTS networkOptions (
 		challenge INTEGER NOT NULL,
-		internal INTEGER NOT NULL CHECK(internal == 0 OR internal == 1),
+		internalnetwork INTEGER NOT NULL CHECK(internalnetwork == 0 OR internalnetwork == 1),
 		FOREIGN KEY (challenge) REFERENCES challenges (id)
 			ON UPDATE CASCADE ON DELETE CASCADE
 	);
@@ -251,10 +251,9 @@ func (m *Manager) safeToRefresh(new *ChallengeMetadata) bool {
 	}
 
 	sameType := old.ChallengeType == new.ChallengeType
-	sameNetworkOptions := reflect.DeepEqual(old.NetworkOptions, new.NetworkOptions)
-	sameContainerOptions := reflect.DeepEqual(old.ContainerOptions, new.ContainerOptions)
+	sameOptions := reflect.DeepEqual(old.ChallengeOptions, new.ChallengeOptions)
 
-	safe := sameType && sameNetworkOptions && sameContainerOptions
+	safe := sameType && sameOptions
 
 	return safe
 }

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -144,12 +144,14 @@ const schemaQuery string = `
 			ON UPDATE RESTRICT ON DELETE CASCADE
 	);
 
-	CREATE TABLE IF NOT EXISTS networkOptions (
-		challenge INTEGER NOT NULL,
-		internalnetwork INTEGER NOT NULL CHECK(internalnetwork == 0 OR internalnetwork == 1),
-		FOREIGN KEY (challenge) REFERENCES challenges (id)
-			ON UPDATE CASCADE ON DELETE CASCADE
-	);
+	-- There are currently not any network-level challenge options, so this table is not created.
+	-- However, this is kept as a placeholder in case additional options are added in the future.
+	--
+	-- CREATE TABLE IF NOT EXISTS networkOptions (
+	--	challenge INTEGER NOT NULL,
+	--	FOREIGN KEY (challenge) REFERENCES challenges (id)
+	--		ON UPDATE CASCADE ON DELETE CASCADE
+	--);
 
 	CREATE TABLE IF NOT EXISTS containerOptions (
 		challenge INTEGER NOT NULL,

--- a/cmgr/database.go
+++ b/cmgr/database.go
@@ -155,15 +155,15 @@ const schemaQuery string = `
 		challenge INTEGER NOT NULL,
 		host TEXT NOT NULL,
 		init INTEGER NOT NULL CHECK(init == 0 OR init == 1),
-		cpus TEXT,
-		memory TEXT,
-		ulimits TEXT,
-		pidslimit INTEGER,
+		cpus TEXT NOT NULL,
+		memory TEXT NOT NULL,
+		ulimits TEXT NOT NULL,
+		pidslimit INTEGER NOT NULL,
 		readonlyrootfs INTEGER NOT NULL CHECK(readonlyrootfs == 0 OR readonlyrootfs == 1),
-		droppedcaps TEXT,
+		droppedcaps TEXT NOT NULL,
 		nonewprivileges INTEGER NOT NULL CHECK(nonewprivileges == 0 OR nonewprivileges == 1),
-		storageopts TEXT,
-		cgroupparent TEXT,
+		storageopts TEXT NOT NULL,
+		cgroupparent TEXT NOT NULL,
 		FOREIGN KEY (challenge) REFERENCES challenges (id)
 			ON UPDATE CASCADE ON DELETE CASCADE
 	);`

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -271,7 +271,7 @@ func (m *Manager) addChallenges(addedChallenges []*ChallengeMetadata) []error {
 				break
 			}
 			m.log.debugf("%s%s: %v", metadata.Id, host_str, dbOpts)
-			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
+			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
 				metadata.Id,
 				host,
 				dbOpts.Init,
@@ -533,7 +533,7 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 				}
 				break
 			}
-			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
+			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
 				metadata.Id,
 				host,
 				dbOpts.Init,

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -271,7 +271,7 @@ func (m *Manager) addChallenges(addedChallenges []*ChallengeMetadata) []error {
 				break
 			}
 			m.log.debugf("%s%s: %v", metadata.Id, host_str, dbOpts)
-			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
 				metadata.Id,
 				host,
 				dbOpts.Init,
@@ -533,7 +533,7 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 				}
 				break
 			}
-			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+			_, err = txn.Exec("INSERT INTO containerOptions(challenge, host, init, cpus, memory, ulimits, pidslimit, readonlyrootfs, droppedcaps, nonewprivileges, storageopts, cgroupparent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
 				metadata.Id,
 				host,
 				dbOpts.Init,

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -84,9 +84,9 @@ func (m *Manager) lookupChallengeMetadata(challenge ChallengeId) (*ChallengeMeta
 		metadata.Attributes[attr.Key] = attr.Value
 	}
 
-	networkOptions := new(NetworkOptions)
+	networkOptions := NetworkOptions{}
 	if err == nil {
-		err = txn.Select(&networkOptions, "SELECT internal FROM network_options WHERE challenge=?", challenge)
+		err = txn.Select(networkOptions, "SELECT internal FROM network_options WHERE challenge=?", challenge)
 	}
 	metadata.NetworkOptions = networkOptions
 

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -86,7 +86,7 @@ func (m *Manager) lookupChallengeMetadata(challenge ChallengeId) (*ChallengeMeta
 
 	networkOptions := NetworkOptions{}
 	if err == nil {
-		err = txn.Select(networkOptions, "SELECT internal FROM network_options WHERE challenge=?", challenge)
+		err = txn.Select(networkOptions, "SELECT internal FROM networkOptions WHERE challenge=?", challenge)
 	}
 	metadata.NetworkOptions = networkOptions
 

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -85,9 +85,11 @@ func (m *Manager) lookupChallengeMetadata(challenge ChallengeId) (*ChallengeMeta
 	}
 
 	networkOptions := new(NetworkOptions)
-	if err == nil {
-		err = txn.Get(networkOptions, "SELECT internalnetwork FROM networkOptions WHERE challenge=?", challenge)
-	}
+	// Note: there are currently no network-level challenge options, but they will be loaded here if added in the future.
+
+	// if err == nil {
+	// 	err = txn.Get(networkOptions, "SELECT '' FROM networkOptions WHERE challenge=?", challenge)
+	// }
 	metadata.ChallengeOptions.NetworkOptions = *networkOptions
 
 	containerOptions := new([]dbContainerOptions)
@@ -243,21 +245,23 @@ func (m *Manager) addChallenges(addedChallenges []*ChallengeMetadata) []error {
 			continue
 		}
 
-		m.log.debugf("%s: %v", metadata.Id, metadata.ChallengeOptions.NetworkOptions)
-		_, err = txn.Exec("INSERT INTO networkOptions(challenge, internalnetwork) VALUES (?, ?);",
-			metadata.Id,
-			metadata.ChallengeOptions.NetworkOptions.InternalNetwork)
-		if err != nil {
-			m.log.error(err)
-			err = txn.Rollback()
-			if err != nil { // If rollback fails, we're in trouble.
-				m.log.error(err)
-				return append(errs, err)
-			}
-		}
-		if err != nil {
-			continue
-		}
+		// Note: there are currently no network-level challenge options, but they will be saved here if added in the future.
+
+		// m.log.debugf("%s: %v", metadata.Id, metadata.ChallengeOptions.NetworkOptions)
+		// _, err = txn.Exec("INSERT INTO networkOptions(challenge) VALUES (?);",
+		// 	metadata.Id,
+		// )
+		// if err != nil {
+		// 	m.log.error(err)
+		// 	err = txn.Rollback()
+		// 	if err != nil { // If rollback fails, we're in trouble.
+		// 		m.log.error(err)
+		// 		return append(errs, err)
+		// 	}
+		// }
+		// if err != nil {
+		// 	continue
+		// }
 
 		for host, opts := range metadata.ChallengeOptions.Overrides {
 			host_str := ""
@@ -487,32 +491,33 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 			continue
 		}
 
-		_, err = txn.Exec("DELETE FROM networkOptions WHERE challenge = ?;", metadata.Id)
+		// Note: there are currently no network-level challenge options, but they would be updated here if added in the future.
 
-		if err != nil {
-			m.log.error(err)
-			err = txn.Rollback()
-			if err != nil { // If rollback fails, we're in trouble.
-				m.log.error(err)
-				return append(errs, err)
-			}
-			continue
-		}
+		// _, err = txn.Exec("DELETE FROM networkOptions WHERE challenge = ?;", metadata.Id)
 
-		_, err = txn.Exec("INSERT INTO networkOptions(challenge, internalnetwork) VALUES (?, ?);",
-			metadata.Id,
-			metadata.ChallengeOptions.NetworkOptions.InternalNetwork)
-		if err != nil {
-			m.log.error(err)
-			err = txn.Rollback()
-			if err != nil { // If rollback fails, we're in trouble.
-				m.log.error(err)
-				return append(errs, err)
-			}
-		}
-		if err != nil {
-			continue
-		}
+		// if err != nil {
+		// 	m.log.error(err)
+		// 	err = txn.Rollback()
+		// 	if err != nil { // If rollback fails, we're in trouble.
+		// 		m.log.error(err)
+		// 		return append(errs, err)
+		// 	}
+		// 	continue
+		// }
+
+		// _, err = txn.Exec("INSERT INTO networkOptions(challenge) VALUES (?);",
+		// 	metadata.Id)
+		// if err != nil {
+		// 	m.log.error(err)
+		// 	err = txn.Rollback()
+		// 	if err != nil { // If rollback fails, we're in trouble.
+		// 		m.log.error(err)
+		// 		return append(errs, err)
+		// 	}
+		// }
+		// if err != nil {
+		// 	continue
+		// }
 
 		_, err = txn.Exec("DELETE FROM containerOptions WHERE challenge = ?;", metadata.Id)
 

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -84,11 +84,11 @@ func (m *Manager) lookupChallengeMetadata(challenge ChallengeId) (*ChallengeMeta
 		metadata.Attributes[attr.Key] = attr.Value
 	}
 
-	networkOptions := NetworkOptions{}
+	networkOptions := new(NetworkOptions)
 	if err == nil {
-		err = txn.Select(networkOptions, "SELECT internal FROM networkOptions WHERE challenge=?", challenge)
+		err = txn.Get(networkOptions, "SELECT internal FROM networkOptions WHERE challenge=?", challenge)
 	}
-	metadata.NetworkOptions = networkOptions
+	metadata.NetworkOptions = *networkOptions
 
 	containerOptions := new([]dbContainerOptions)
 	if err == nil {

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -665,86 +665,96 @@ func (m *Manager) removeChallenges(removedChallenges []*ChallengeMetadata) error
 type dbContainerOptions struct {
 	Host            string
 	Init            bool
-	Cpus            *string
-	Memory          *string
-	Ulimits         *string
-	PidsLimit       *int64
+	Cpus            string
+	Memory          string
+	Ulimits         string
+	PidsLimit       int64
 	ReadonlyRootfs  bool
-	DroppedCaps     *string
+	DroppedCaps     string
 	NoNewPrivileges bool
-	StorageOpts     *string
-	CgroupParent    *string
+	StorageOpts     string
+	CgroupParent    string
 }
 
 func newFromDbContainerOptions(dbOpts dbContainerOptions) (ContainerOptions, error) {
 	cOpts := ContainerOptions{}
+
 	cOpts.Init = dbOpts.Init
+
 	cOpts.Cpus = dbOpts.Cpus
+
 	cOpts.Memory = dbOpts.Memory
-	if dbOpts.Ulimits != nil {
-		ulimits := new([]string)
-		err := json.Unmarshal([]byte(*dbOpts.Ulimits), &ulimits)
-		if err != nil {
-			return cOpts, err
-		}
-		cOpts.Ulimits = *ulimits
+
+	ulimits := new([]string)
+	err := json.Unmarshal([]byte(dbOpts.Ulimits), &ulimits)
+	if err != nil {
+		return cOpts, err
 	}
+	cOpts.Ulimits = *ulimits
+
 	cOpts.PidsLimit = dbOpts.PidsLimit
+
 	cOpts.ReadonlyRootfs = dbOpts.ReadonlyRootfs
-	if dbOpts.DroppedCaps != nil {
-		droppedCaps := new([]string)
-		err := json.Unmarshal([]byte(*dbOpts.DroppedCaps), &droppedCaps)
-		if err != nil {
-			return cOpts, err
-		}
-		cOpts.DroppedCaps = *droppedCaps
+
+	droppedCaps := new([]string)
+	err = json.Unmarshal([]byte(dbOpts.DroppedCaps), &droppedCaps)
+	if err != nil {
+		return cOpts, err
 	}
+	cOpts.DroppedCaps = *droppedCaps
+
 	cOpts.NoNewPrivileges = dbOpts.NoNewPrivileges
-	if dbOpts.StorageOpts != nil {
-		storageOpts := make(map[string]string)
-		err := json.Unmarshal([]byte(*dbOpts.StorageOpts), &storageOpts)
-		if err != nil {
-			return cOpts, err
-		}
-		cOpts.StorageOpts = storageOpts
+
+	storageOpts := make(map[string]string)
+	err = json.Unmarshal([]byte(dbOpts.StorageOpts), &storageOpts)
+	if err != nil {
+		return cOpts, err
 	}
+	cOpts.StorageOpts = storageOpts
+
 	cOpts.CgroupParent = dbOpts.CgroupParent
+
 	return cOpts, nil
 }
 
 func (cOpts ContainerOptions) toDbContainerOptions() (dbContainerOptions, error) {
 	dbOpts := dbContainerOptions{}
+
 	dbOpts.Init = cOpts.Init
+
 	dbOpts.Cpus = cOpts.Cpus
+
 	dbOpts.Memory = cOpts.Memory
-	if cOpts.Ulimits != nil {
-		ulimitsBytes, err := json.Marshal(cOpts.Ulimits)
-		if err != nil {
-			return dbOpts, err
-		}
-		ulimits := string(ulimitsBytes)
-		dbOpts.Ulimits = &ulimits
+
+	ulimitsBytes, err := json.Marshal(cOpts.Ulimits)
+	if err != nil {
+		return dbOpts, err
 	}
+	ulimits := string(ulimitsBytes)
+	dbOpts.Ulimits = ulimits
+
 	dbOpts.PidsLimit = cOpts.PidsLimit
+
 	dbOpts.ReadonlyRootfs = cOpts.ReadonlyRootfs
-	if cOpts.DroppedCaps != nil {
-		droppedCapsBytes, err := json.Marshal(cOpts.DroppedCaps)
-		if err != nil {
-			return dbOpts, err
-		}
-		droppedCaps := string(droppedCapsBytes)
-		dbOpts.DroppedCaps = &droppedCaps
+
+	droppedCapsBytes, err := json.Marshal(cOpts.DroppedCaps)
+	if err != nil {
+		return dbOpts, err
 	}
+	droppedCaps := string(droppedCapsBytes)
+	dbOpts.DroppedCaps = droppedCaps
+
 	dbOpts.NoNewPrivileges = cOpts.NoNewPrivileges
-	if cOpts.StorageOpts != nil {
-		storageOptsBytes, err := json.Marshal(cOpts.StorageOpts)
-		if err != nil {
-			return dbOpts, err
-		}
-		storageOpts := string(storageOptsBytes)
-		dbOpts.StorageOpts = &storageOpts
+
+	storageOptsBytes, err := json.Marshal(cOpts.StorageOpts)
+	if err != nil {
+		return dbOpts, err
 	}
+	storageOpts := string(storageOptsBytes)
+	dbOpts.StorageOpts = storageOpts
+
 	dbOpts.CgroupParent = cOpts.CgroupParent
+
 	return dbOpts, nil
 }
 

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -99,6 +99,9 @@ func (m *Manager) lookupChallengeMetadata(challenge ChallengeId) (*ChallengeMeta
 		if err != nil {
 			break
 		}
+		if metadata.ContainerOptions == nil {
+			metadata.ContainerOptions = make(ContainerOptionsWrapper)
+		}
 		metadata.ContainerOptions[dbOpts.Host] = cOpts
 	}
 
@@ -685,32 +688,32 @@ func newFromDbContainerOptions(dbOpts dbContainerOptions) (ContainerOptions, err
 
 	cOpts.Memory = dbOpts.Memory
 
-	ulimits := new([]string)
+	ulimits := make([]string, 0)
 	err := json.Unmarshal([]byte(dbOpts.Ulimits), &ulimits)
 	if err != nil {
 		return cOpts, err
 	}
-	cOpts.Ulimits = *ulimits
+	cOpts.Ulimits = ulimits
 
 	cOpts.PidsLimit = dbOpts.PidsLimit
 
 	cOpts.ReadonlyRootfs = dbOpts.ReadonlyRootfs
 
-	droppedCaps := new([]string)
+	droppedCaps := make([]string, 0)
 	err = json.Unmarshal([]byte(dbOpts.DroppedCaps), &droppedCaps)
 	if err != nil {
 		return cOpts, err
 	}
-	cOpts.DroppedCaps = *droppedCaps
+	cOpts.DroppedCaps = droppedCaps
 
 	cOpts.NoNewPrivileges = dbOpts.NoNewPrivileges
 
-	storageOpts := new([]string)
+	storageOpts := make([]string, 0)
 	err = json.Unmarshal([]byte(dbOpts.StorageOpts), &storageOpts)
 	if err != nil {
 		return cOpts, err
 	}
-	cOpts.StorageOpts = *storageOpts
+	cOpts.StorageOpts = storageOpts
 
 	cOpts.CgroupParent = dbOpts.CgroupParent
 

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -102,7 +102,7 @@ func (m *Manager) lookupChallengeMetadata(challenge ChallengeId) (*ChallengeMeta
 			break
 		}
 		if metadata.ChallengeOptions.Overrides == nil {
-			metadata.ChallengeOptions.Overrides = make(ContainerOptionsWrapper)
+			metadata.ChallengeOptions.Overrides = make(map[string]ContainerOptions)
 		}
 		metadata.ChallengeOptions.Overrides[dbOpts.Host] = cOpts
 	}

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -613,7 +613,8 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 						errs = append(errs, err)
 						continue
 					}
-					// Restart containers
+
+					// Recreate network and containers
 					instances, err := m.getBuildInstances(build.Id)
 					if err != nil {
 						errs = append(errs, err)
@@ -623,6 +624,12 @@ func (m *Manager) updateChallenges(updatedChallenges []*ChallengeMetadata, rebui
 						instance, err := m.lookupInstanceMetadata(iid)
 						if err == nil {
 							err = m.stopContainers(instance)
+						}
+						if err == nil {
+							err = m.stopNetwork(instance)
+						}
+						if err == nil {
+							err = m.startNetwork(instance, cMeta.NetworkOptions)
 						}
 						if err == nil {
 							err = m.startContainers(build, instance, cMeta.ContainerOptions)

--- a/cmgr/database_challenges.go
+++ b/cmgr/database_challenges.go
@@ -661,7 +661,7 @@ func (m *Manager) removeChallenges(removedChallenges []*ChallengeMetadata) error
 }
 
 // Database representation of ContainerOptions
-// Complex list/map options are serialized to JSON strings
+// List-based options are serialized as JSON strings
 type dbContainerOptions struct {
 	Host            string
 	Init            bool
@@ -705,12 +705,12 @@ func newFromDbContainerOptions(dbOpts dbContainerOptions) (ContainerOptions, err
 
 	cOpts.NoNewPrivileges = dbOpts.NoNewPrivileges
 
-	storageOpts := make(map[string]string)
+	storageOpts := new([]string)
 	err = json.Unmarshal([]byte(dbOpts.StorageOpts), &storageOpts)
 	if err != nil {
 		return cOpts, err
 	}
-	cOpts.StorageOpts = storageOpts
+	cOpts.StorageOpts = *storageOpts
 
 	cOpts.CgroupParent = dbOpts.CgroupParent
 

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -708,6 +708,9 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			if cOpts.NoNewPrivileges {
 				hConfig.SecurityOpt = append(hConfig.SecurityOpt, "no-new-privileges:true")
 			}
+			for k, v := range cOpts.StorageOpt {
+				hConfig.StorageOpt[k] = v
+			}
 		}
 
 		hostInfo, err := m.cli.Info(m.ctx)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
@@ -703,7 +704,7 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 				hConfig.PidsLimit = cOpts.PidsLimit
 			}
 			hConfig.ReadonlyRootfs = cOpts.ReadonlyRootfs
-
+			hConfig.CapDrop = (strslice.StrSlice)(cOpts.CapDrop)
 		}
 
 		hostInfo, err := m.cli.Info(m.ctx)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"github.com/docker/go-units"
 )
 
 //go:embed dockerfiles/seccomp.json
@@ -679,6 +680,13 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 					return err
 				}
 				hConfig.NanoCPUs = nanoCpus
+			}
+			if cOpts.Memory != nil {
+				memoryBytes, err := units.RAMInBytes(*cOpts.Memory)
+				if err != nil {
+					return err
+				}
+				hConfig.Memory = memoryBytes
 			}
 		}
 

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -599,7 +599,7 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 	return err
 }
 
-func (m *Manager) startNetwork(instance *InstanceMetadata, opts *NetworkOptions) error {
+func (m *Manager) startNetwork(instance *InstanceMetadata, opts NetworkOptions) error {
 	netSpec := types.NetworkCreate{
 		Driver:   "bridge",
 		Internal: opts.Internal,

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -601,8 +601,7 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 
 func (m *Manager) startNetwork(instance *InstanceMetadata, opts NetworkOptions) error {
 	netSpec := types.NetworkCreate{
-		Driver:   "bridge",
-		Internal: opts.InternalNetwork,
+		Driver: "bridge",
 	}
 	netname := instance.getNetworkName()
 	_, err := m.cli.NetworkCreate(m.ctx, netname, netSpec)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -718,9 +718,8 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			if cOpts.NoNewPrivileges {
 				hConfig.SecurityOpt = append(hConfig.SecurityOpt, "no-new-privileges:true")
 			}
-			for _, storageOpt := range cOpts.StorageOpts {
-				subs := strings.SplitN(storageOpt, "=", 2)
-				hConfig.StorageOpt[subs[0]] = subs[1]
+			if cOpts.DiskQuota != "" {
+				hConfig.StorageOpt["size"] = cOpts.DiskQuota
 			}
 			if cOpts.CgroupParent != "" {
 				hConfig.CgroupParent = cOpts.CgroupParent

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -685,15 +685,15 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 		}
 		if hasContainerOpts {
 			hConfig.Init = &cOpts.Init
-			if cOpts.Cpus != nil {
-				nanoCpus, err := dockeropts.ParseCPUs(*cOpts.Cpus)
+			if cOpts.Cpus != "" {
+				nanoCpus, err := dockeropts.ParseCPUs(cOpts.Cpus)
 				if err != nil {
 					return err
 				}
 				hConfig.NanoCPUs = nanoCpus
 			}
-			if cOpts.Memory != nil {
-				memoryBytes, err := units.RAMInBytes(*cOpts.Memory)
+			if cOpts.Memory != "" {
+				memoryBytes, err := units.RAMInBytes(cOpts.Memory)
 				if err != nil {
 					return err
 				}
@@ -710,8 +710,8 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 				}
 				hConfig.Ulimits = limits
 			}
-			if cOpts.PidsLimit != nil {
-				hConfig.PidsLimit = cOpts.PidsLimit
+			if cOpts.PidsLimit != 0 {
+				hConfig.PidsLimit = &cOpts.PidsLimit
 			}
 			hConfig.ReadonlyRootfs = cOpts.ReadonlyRootfs
 			hConfig.CapDrop = (strslice.StrSlice)(cOpts.DroppedCaps)
@@ -721,8 +721,8 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			for k, v := range cOpts.StorageOpts {
 				hConfig.StorageOpt[k] = v
 			}
-			if cOpts.CgroupParent != nil {
-				hConfig.CgroupParent = *cOpts.CgroupParent
+			if cOpts.CgroupParent != "" {
+				hConfig.CgroupParent = cOpts.CgroupParent
 			}
 		}
 

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -676,7 +676,7 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 
 		hasContainerOpts := false
 		cOpts, hasContainerOpts := opts[""]
-		if hostCOpts, ok := opts[image.Host]; ok {
+		if hostCOpts, ok := opts[strings.ToLower(image.Host)]; ok {
 			cOpts = hostCOpts
 			hasContainerOpts = true
 		}

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -602,7 +602,7 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 func (m *Manager) startNetwork(instance *InstanceMetadata, opts NetworkOptions) error {
 	netSpec := types.NetworkCreate{
 		Driver:   "bridge",
-		Internal: opts.Internal,
+		Internal: opts.InternalNetwork,
 	}
 	netname := instance.getNetworkName()
 	_, err := m.cli.NetworkCreate(m.ctx, netname, netSpec)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -719,7 +719,15 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 				hConfig.SecurityOpt = append(hConfig.SecurityOpt, "no-new-privileges:true")
 			}
 			if cOpts.DiskQuota != "" {
-				hConfig.StorageOpt["size"] = cOpts.DiskQuota
+				_, quotas_enabled := os.LookupEnv(DISK_QUOTA_ENV)
+				if quotas_enabled {
+					var storageOpt = map[string]string{
+						"size": cOpts.DiskQuota,
+					}
+					hConfig.StorageOpt = storageOpt
+				} else {
+					m.log.warnf("disk quota for %s container '%s' ignored (disk quotas are not enabled)", build.Challenge, image.Host)
+				}
 			}
 			if cOpts.CgroupParent != "" {
 				hConfig.CgroupParent = cOpts.CgroupParent

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -734,7 +734,7 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 
 		if hostInfo.OSType == "linux" {
 			m.log.debug("inserting custom seccomp profile")
-			hConfig.SecurityOpt = []string{"seccomp:" + seccompPolicy}
+			hConfig.SecurityOpt = append(hConfig.SecurityOpt, "seccomp:"+seccompPolicy)
 		}
 
 		nConfig := network.NetworkingConfig{

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -699,6 +699,10 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 				}
 				hConfig.Ulimits = limits
 			}
+			if cOpts.PidsLimit != nil {
+				hConfig.PidsLimit = cOpts.PidsLimit
+			}
+
 		}
 
 		hostInfo, err := m.cli.Info(m.ctx)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -704,11 +704,11 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 				hConfig.PidsLimit = cOpts.PidsLimit
 			}
 			hConfig.ReadonlyRootfs = cOpts.ReadonlyRootfs
-			hConfig.CapDrop = (strslice.StrSlice)(cOpts.CapDrop)
+			hConfig.CapDrop = (strslice.StrSlice)(cOpts.DroppedCaps)
 			if cOpts.NoNewPrivileges {
 				hConfig.SecurityOpt = append(hConfig.SecurityOpt, "no-new-privileges:true")
 			}
-			for k, v := range cOpts.StorageOpt {
+			for k, v := range cOpts.StorageOpts {
 				hConfig.StorageOpt[k] = v
 			}
 			if cOpts.CgroupParent != nil {

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -673,7 +673,17 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			PortBindings:  publishedPorts,
 			RestartPolicy: container.RestartPolicy{Name: "always"},
 		}
-		if cOpts, ok := opts[image.Host]; ok {
+
+		hasContainerOpts := false
+		cOpts, hasContainerOpts := opts[""]
+		if hostCOpts, ok := opts[image.Host]; ok {
+			cOpts = hostCOpts
+			hasContainerOpts = true
+		}
+		if image.Host == "builder" {
+			hasContainerOpts = false
+		}
+		if hasContainerOpts {
 			hConfig.Init = &cOpts.Init
 			if cOpts.Cpus != nil {
 				nanoCpus, err := dockeropts.ParseCPUs(*cOpts.Cpus)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -702,6 +702,7 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			if cOpts.PidsLimit != nil {
 				hConfig.PidsLimit = cOpts.PidsLimit
 			}
+			hConfig.ReadonlyRootfs = cOpts.ReadonlyRootfs
 
 		}
 

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -705,6 +705,9 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			}
 			hConfig.ReadonlyRootfs = cOpts.ReadonlyRootfs
 			hConfig.CapDrop = (strslice.StrSlice)(cOpts.CapDrop)
+			if cOpts.NoNewPrivileges {
+				hConfig.SecurityOpt = append(hConfig.SecurityOpt, "no-new-privileges:true")
+			}
 		}
 
 		hostInfo, err := m.cli.Info(m.ctx)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -596,9 +596,10 @@ func (m *Manager) executeBuild(cMeta *ChallengeMetadata, bMeta *BuildMetadata, b
 	return err
 }
 
-func (m *Manager) startNetwork(instance *InstanceMetadata) error {
+func (m *Manager) startNetwork(instance *InstanceMetadata, opts *NetworkOptions) error {
 	netSpec := types.NetworkCreate{
-		Driver: "bridge",
+		Driver:   "bridge",
+		Internal: opts.Internal,
 	}
 	netname := instance.getNetworkName()
 	_, err := m.cli.NetworkCreate(m.ctx, netname, netSpec)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -688,6 +688,17 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 				}
 				hConfig.Memory = memoryBytes
 			}
+			if len(cOpts.Ulimits) > 0 {
+				limits := make([]*units.Ulimit, len(cOpts.Ulimits))
+				for i, limitStr := range cOpts.Ulimits {
+					limit, err := units.ParseUlimit(limitStr)
+					if err != nil {
+						return err
+					}
+					limits[i] = limit
+				}
+				hConfig.Ulimits = limits
+			}
 		}
 
 		hostInfo, err := m.cli.Info(m.ctx)

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -718,8 +718,9 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			if cOpts.NoNewPrivileges {
 				hConfig.SecurityOpt = append(hConfig.SecurityOpt, "no-new-privileges:true")
 			}
-			for k, v := range cOpts.StorageOpts {
-				hConfig.StorageOpt[k] = v
+			for _, storageOpt := range cOpts.StorageOpts {
+				subs := strings.SplitN(storageOpt, "=", 2)
+				hConfig.StorageOpt[subs[0]] = subs[1]
 			}
 			if cOpts.CgroupParent != "" {
 				hConfig.CgroupParent = cOpts.CgroupParent

--- a/cmgr/docker.go
+++ b/cmgr/docker.go
@@ -711,6 +711,9 @@ func (m *Manager) startContainers(build *BuildMetadata, instance *InstanceMetada
 			for k, v := range cOpts.StorageOpt {
 				hConfig.StorageOpt[k] = v
 			}
+			if cOpts.CgroupParent != nil {
+				hConfig.CgroupParent = *cOpts.CgroupParent
+			}
 		}
 
 		hostInfo, err := m.cli.Info(m.ctx)

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -312,6 +312,14 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 				m.log.error(lastErr)
 			}
 		}
+
+		if opts.PidsLimit != nil {
+			if *opts.PidsLimit < -1 {
+				lastErr = fmt.Errorf("%vinvalid PidsLimit container option (must be >= -1)", hostStr)
+				m.log.error(lastErr)
+			}
+		}
+
 	}
 
 	return lastErr

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -310,9 +310,14 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 		}
 
 		for _, ulimit := range opts.Ulimits {
-			_, err = units.ParseUlimit(ulimit)
+			limit, err := units.ParseUlimit(ulimit)
 			if err != nil {
 				lastErr = fmt.Errorf("%serror parsing ulimit container option: %v", hostStr, err)
+				m.log.error(lastErr)
+			}
+			// See https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit
+			if limit.Name == "nproc" {
+				lastErr = fmt.Errorf("%snproc ulimits are not supported, use the PidsLimit container option instead", hostStr)
 				m.log.error(lastErr)
 			}
 		}

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -45,6 +45,12 @@ func (m *Manager) loadChallenge(path string, info os.FileInfo) (*ChallengeMetada
 	info, err = os.Stat(solverPath)
 	md.SolveScript = err == nil && info.IsDir()
 
+	if md.ChallengeOptions.Overrides == nil {
+		md.ChallengeOptions.Overrides = make(map[string]ContainerOptions)
+	}
+	md.ChallengeOptions.Overrides[""] = md.ChallengeOptions.ContainerOptions
+	m.log.debugf("challenge options: %#v", md.ChallengeOptions)
+
 	err = m.processDockerfile(md)
 	if err != nil {
 		return md, err
@@ -287,7 +293,7 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 	}
 
 	// Validate ContainerOptions
-	for host, opts := range md.ContainerOptions {
+	for host, opts := range md.ChallengeOptions.Overrides {
 		hostStr := ""
 		if host != "" {
 			hostStr = fmt.Sprintf("host %s: ", host)
@@ -599,7 +605,7 @@ func (m *Manager) processDockerfile(md *ChallengeMetadata) error {
 	}
 
 	// Validate ContainerOptions hosts
-	for opt_host := range md.ContainerOptions {
+	for opt_host := range md.ChallengeOptions.Overrides {
 		if opt_host == "" {
 			continue
 		}

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -293,16 +293,20 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			hostStr = fmt.Sprintf("host %v: ", host)
 		}
 
-		_, err := dockeropts.ParseCPUs(*opts.Cpus)
-		if err != nil {
-			lastErr = fmt.Errorf("%verror parsing CPUs container option: %v", hostStr, err)
-			m.log.error(lastErr)
+		if opts.Cpus != nil {
+			_, err := dockeropts.ParseCPUs(*opts.Cpus)
+			if err != nil {
+				lastErr = fmt.Errorf("%verror parsing CPUs container option: %v", hostStr, err)
+				m.log.error(lastErr)
+			}
 		}
 
-		_, err = units.RAMInBytes(*opts.Memory)
-		if err != nil {
-			lastErr = fmt.Errorf("%verror parsing memory container option: %v", hostStr, err)
-			m.log.error(lastErr)
+		if opts.Memory != nil {
+			_, err = units.RAMInBytes(*opts.Memory)
+			if err != nil {
+				lastErr = fmt.Errorf("%verror parsing memory container option: %v", hostStr, err)
+				m.log.error(lastErr)
+			}
 		}
 
 		for _, ulimit := range opts.Ulimits {

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -348,6 +348,14 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			}
 		}
 
+		for _, sOpt := range opts.StorageOpts {
+			subs := strings.SplitN(sOpt, "=", 2)
+			if len(subs) < 2 {
+				lastErr = fmt.Errorf("%sinvalid StorageOpts container option: %s", hostStr, sOpt)
+				m.log.error(lastErr)
+			}
+		}
+
 	}
 
 	return lastErr

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -341,10 +341,10 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			"CAP_SETUID":           {},
 			"CAP_SYS_CHROOT":       {},
 		}
-		for _, cap := range opts.CapDrop {
+		for _, cap := range opts.DroppedCaps {
 			if _, ok := droppable_capabilities[cap]; !ok {
 				if _, ok = droppable_capabilities[fmt.Sprintf("CAP_%s", cap)]; !ok {
-					lastErr = fmt.Errorf("%sinvalid CapDrop container option: %s", hostStr, cap)
+					lastErr = fmt.Errorf("%sinvalid DroppedCaps container option: %s", hostStr, cap)
 					m.log.error(lastErr)
 				}
 			}

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	dockeropts "github.com/docker/cli/opts"
+	"github.com/docker/go-units"
 )
 
 func (m *Manager) loadChallenge(path string, info os.FileInfo) (*ChallengeMetadata, error) {
@@ -295,6 +296,12 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 		_, err := dockeropts.ParseCPUs(*opts.Cpus)
 		if err != nil {
 			lastErr = fmt.Errorf("%verror parsing CPUs container option: %v", hostStr, err)
+			m.log.error(lastErr)
+		}
+
+		_, err = units.RAMInBytes(*opts.Memory)
+		if err != nil {
+			lastErr = fmt.Errorf("%verror parsing memory container option: %v", hostStr, err)
 			m.log.error(lastErr)
 		}
 	}

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -302,7 +302,7 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 		if opts.Cpus != "" {
 			_, err := dockeropts.ParseCPUs(opts.Cpus)
 			if err != nil {
-				lastErr = fmt.Errorf("%serror parsing CPUs container option: %v", hostStr, err)
+				lastErr = fmt.Errorf("%serror parsing cpus container option: %v", hostStr, err)
 				m.log.error(lastErr)
 			}
 		}
@@ -318,18 +318,18 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 		for _, ulimit := range opts.Ulimits {
 			limit, err := units.ParseUlimit(ulimit)
 			if err != nil {
-				lastErr = fmt.Errorf("%serror parsing ulimit container option: %v", hostStr, err)
+				lastErr = fmt.Errorf("%serror parsing ulimits container option: %v", hostStr, err)
 				m.log.error(lastErr)
 			}
 			// See https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit
 			if limit.Name == "nproc" {
-				lastErr = fmt.Errorf("%snproc ulimits are not supported, use the PidsLimit container option instead", hostStr)
+				lastErr = fmt.Errorf("%snproc ulimits are not supported, use the pidslimit container option instead", hostStr)
 				m.log.error(lastErr)
 			}
 		}
 
 		if opts.PidsLimit < -1 {
-			lastErr = fmt.Errorf("%sinvalid PidsLimit container option (must be >= -1)", hostStr)
+			lastErr = fmt.Errorf("%sinvalid pidslimit container option (must be >= -1)", hostStr)
 			m.log.error(lastErr)
 		}
 

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -304,6 +304,14 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			lastErr = fmt.Errorf("%verror parsing memory container option: %v", hostStr, err)
 			m.log.error(lastErr)
 		}
+
+		for _, ulimit := range opts.Ulimits {
+			_, err = units.ParseUlimit(ulimit)
+			if err != nil {
+				lastErr = fmt.Errorf("%verror parsing ulimit container option: %v", hostStr, err)
+				m.log.error(lastErr)
+			}
+		}
 	}
 
 	return lastErr

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -353,14 +353,13 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			}
 		}
 
-		for _, sOpt := range opts.StorageOpts {
-			subs := strings.SplitN(sOpt, "=", 2)
-			if len(subs) < 2 {
-				lastErr = fmt.Errorf("%sinvalid StorageOpts container option: %s", hostStr, sOpt)
+		if opts.DiskQuota != "" {
+			_, err := units.RAMInBytes(opts.DiskQuota) // Despite its name, Docker uses this method to parse the size= storage option.
+			if err != nil {
+				lastErr = fmt.Errorf("%serror parsing DiskQuota container option: %v", hostStr, err)
 				m.log.error(lastErr)
 			}
 		}
-
 	}
 
 	return lastErr

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -590,6 +590,9 @@ func (m *Manager) processDockerfile(md *ChallengeMetadata) error {
 
 	// Validate ContainerOptions hosts
 	for opt_host := range md.ContainerOptions {
+		if opt_host == "" {
+			continue
+		}
 		found := false
 		for _, host := range hostNames {
 			if host.Name == opt_host {

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -519,6 +519,22 @@ func (m *Manager) processDockerfile(md *ChallengeMetadata) error {
 		md.PortMap[portName] = PortInfo{host.Name, port}
 	}
 
+	// Validate ContainerOptions hosts
+	for opt_host := range md.ContainerOptions {
+		found := false
+		for _, host := range hostNames {
+			if host.Name == opt_host {
+				found = true
+				break
+			}
+		}
+		if !found {
+			err = fmt.Errorf("container options are specified for host %s, which is not present in Dockerfile", opt_host)
+			m.log.error(err)
+			return err
+		}
+	}
+
 	return err
 }
 

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -293,16 +293,16 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			hostStr = fmt.Sprintf("host %s: ", host)
 		}
 
-		if opts.Cpus != nil {
-			_, err := dockeropts.ParseCPUs(*opts.Cpus)
+		if opts.Cpus != "" {
+			_, err := dockeropts.ParseCPUs(opts.Cpus)
 			if err != nil {
 				lastErr = fmt.Errorf("%serror parsing CPUs container option: %v", hostStr, err)
 				m.log.error(lastErr)
 			}
 		}
 
-		if opts.Memory != nil {
-			_, err = units.RAMInBytes(*opts.Memory)
+		if opts.Memory != "" {
+			_, err = units.RAMInBytes(opts.Memory)
 			if err != nil {
 				lastErr = fmt.Errorf("%serror parsing memory container option: %v", hostStr, err)
 				m.log.error(lastErr)
@@ -317,11 +317,9 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 			}
 		}
 
-		if opts.PidsLimit != nil {
-			if *opts.PidsLimit < -1 {
-				lastErr = fmt.Errorf("%sinvalid PidsLimit container option (must be >= -1)", hostStr)
-				m.log.error(lastErr)
-			}
+		if opts.PidsLimit < -1 {
+			lastErr = fmt.Errorf("%sinvalid PidsLimit container option (must be >= -1)", hostStr)
+			m.log.error(lastErr)
 		}
 
 		droppable_capabilities := map[string]struct{}{

--- a/cmgr/loader.go
+++ b/cmgr/loader.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	dockeropts "github.com/docker/cli/opts"
 )
 
 func (m *Manager) loadChallenge(path string, info os.FileInfo) (*ChallengeMetadata, error) {
@@ -279,6 +281,20 @@ func (m *Manager) validateMetadata(md *ChallengeMetadata) error {
 	for port, used := range refPort {
 		if !used && md.ChallengeType != "hacksport" {
 			lastErr = fmt.Errorf("port '%s' published but not referenced: %s", port, md.Path)
+			m.log.error(lastErr)
+		}
+	}
+
+	// Validate ContainerOptions
+	for host, opts := range md.ContainerOptions {
+		hostStr := ""
+		if host != "" {
+			hostStr = fmt.Sprintf("host %v: ", host)
+		}
+
+		_, err := dockeropts.ParseCPUs(*opts.Cpus)
+		if err != nil {
+			lastErr = fmt.Errorf("%verror parsing CPUs container option: %v", hostStr, err)
 			m.log.error(lastErr)
 		}
 	}

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -45,7 +45,6 @@ func parseBool(s string) (bool, error) {
 var sectionRe *regexp.Regexp = regexp.MustCompile(`^##\s*(.+)`)
 var kvLineRe *regexp.Regexp = regexp.MustCompile(`^\s*-\s*(\w+):\s*(.*)`)
 var tagLineRe *regexp.Regexp = regexp.MustCompile(`^\s*-\s*(\w+)\s*$`)
-var optionLineRe *regexp.Regexp = regexp.MustCompile(`^\s*-\s*([\w=]+)\s*$`)
 
 func (m *Manager) loadMarkdownChallenge(path string, info os.FileInfo) (*ChallengeMetadata, error) {
 	m.log.debugf("Found challenge Markdown at %s", path)
@@ -156,21 +155,20 @@ func (m *Manager) loadMarkdownChallenge(path string, info os.FileInfo) (*Challen
 func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, lines []string, startIdx, endIdx int) error {
 	var err error
 	m.log.debugf("processing markdown: section='%s' start=%d end=%d", section, startIdx, endIdx)
-	sectionLower := strings.ToLower(section)
-	switch {
-	case sectionLower == "description":
+	switch strings.ToLower(section) {
+	case "description":
 		text, tmpErr := m.parseMarkdown(strings.Join(lines[startIdx:endIdx], "\n"))
 		md.Description = text
 		err = tmpErr
-	case sectionLower == "details":
+	case "details":
 		text, tmpErr := m.parseMarkdown(strings.Join(lines[startIdx:endIdx], "\n"))
 		md.Details = text
 		err = tmpErr
-	case sectionLower == "hints":
+	case "hints":
 		hints, tmpErr := m.parseHints(lines[startIdx:endIdx])
 		md.Hints = hints
 		err = tmpErr
-	case sectionLower == "tags":
+	case "tags":
 		md.Tags = []string{}
 		for i, rawLine := range lines[startIdx:endIdx] {
 			line := strings.TrimSpace(rawLine)
@@ -187,7 +185,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 
 			md.Tags = append(md.Tags, match[1])
 		}
-	case sectionLower == "attributes":
+	case "attributes":
 		for i := startIdx; i < endIdx; i++ {
 			line := strings.TrimSpace(lines[i])
 			if line == "" {
@@ -203,7 +201,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 
 			md.Attributes[match[1]] = match[2]
 		}
-	case strings.HasPrefix(sectionLower, "challenge options"):
+	case "challenge options":
 		yamlStart := 0
 		yamlEnd := 0
 		for i := startIdx; i < endIdx; i++ {

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -200,6 +200,37 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 
 			md.Attributes[match[1]] = match[2]
 		}
+	case "network options":
+		for i := startIdx; i < endIdx; i++ {
+			line := strings.TrimSpace(lines[i])
+			if line == "" {
+				continue
+			}
+
+			match := kvLineRe.FindStringSubmatch(line)
+			if match == nil {
+				err = fmt.Errorf("unexpected text in 'network options' section on line %d: %s", i, md.Path)
+				m.log.error(err)
+				continue
+			}
+
+			option := strings.ToLower(match[1])
+			switch option {
+			case "internal":
+				value, err := strconv.ParseBool(match[2])
+				if err != nil {
+					err = fmt.Errorf("unable to parse 'internal' option value on line %d: %s", i, md.Path)
+					m.log.error(err)
+					continue
+				}
+				md.NetworkOptions.Internal = value
+				continue
+			default:
+				err = fmt.Errorf("unexpected option '%s' in 'network options' section on line %d: %s", option, i, md.Path)
+				continue
+			}
+		}
+
 	default:
 		attrVal := strings.TrimSpace(strings.Join(lines[startIdx:endIdx], "\n"))
 		md.Attributes[section] = attrVal

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -382,32 +382,13 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				}
 				opts.NoNewPrivileges = value
 				continue
-			case "storageopts":
-				if value != "" {
-					err = fmt.Errorf("inline value provided for 'storageopts' option on line %d (use unordered list): %s", i+1, md.Path)
+			case "diskquota":
+				if value == "" {
+					err = fmt.Errorf("missing value for 'diskquota' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
-				for i < endIdx-1 {
-					i++
-					valLine := strings.TrimSpace(lines[i])
-					if valLine == "" {
-						continue
-					}
-					valMatch := kvLineRe.FindStringSubmatch(valLine)
-					if valMatch != nil {
-						// Found next option line, rewind and break
-						i--
-						break
-					}
-					valMatch = optionLineRe.FindStringSubmatch(valLine)
-					if valMatch == nil {
-						err = fmt.Errorf("invalid value provided for 'storageopts' option on line %d: %s", i+1, md.Path)
-						m.log.error(err)
-						continue
-					}
-					opts.StorageOpts = append(opts.StorageOpts, valMatch[1])
-				}
+				opts.DiskQuota = value
 				continue
 			case "cgroupparent":
 				if value == "" {

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -179,7 +179,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 
 			match := tagLineRe.FindStringSubmatch(line)
 			if match == nil {
-				err = fmt.Errorf("unexpected text in 'tags' section on line %d: %s", i, md.Path)
+				err = fmt.Errorf("unexpected text in 'tags' section on line %d: %s", i+1, md.Path)
 				m.log.error(err)
 				continue
 			}
@@ -195,7 +195,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 
 			match := kvLineRe.FindStringSubmatch(line)
 			if match == nil {
-				err = fmt.Errorf("unexpected text in 'attributes' section on line %d: %s", i, md.Path)
+				err = fmt.Errorf("unexpected text in 'attributes' section on line %d: %s", i+1, md.Path)
 				m.log.error(err)
 				continue
 			}
@@ -211,7 +211,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 
 			match := kvLineRe.FindStringSubmatch(line)
 			if match == nil {
-				err = fmt.Errorf("unexpected text in 'network options' section on line %d: %s", i, md.Path)
+				err = fmt.Errorf("unexpected text in 'network options' section on line %d: %s", i+1, md.Path)
 				m.log.error(err)
 				continue
 			}
@@ -221,14 +221,14 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 			case "internal":
 				value, err := parseBool(match[2])
 				if err != nil {
-					err = fmt.Errorf("unable to parse 'internal' option value on line %d: %s", i, md.Path)
+					err = fmt.Errorf("unable to parse 'internal' option value on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
 				md.NetworkOptions.Internal = value
 				continue
 			default:
-				err = fmt.Errorf("unexpected option '%s' in 'network options' section on line %d: %s", option, i, md.Path)
+				err = fmt.Errorf("unexpected option '%s' in 'network options' section on line %d: %s", option, i+1, md.Path)
 				continue
 			}
 		}
@@ -246,7 +246,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 			}
 			match := kvLineRe.FindStringSubmatch(line)
 			if match == nil {
-				err = fmt.Errorf("unexpected text in 'container options' section on line %d: %s", i, md.Path)
+				err = fmt.Errorf("unexpected text in 'container options' section on line %d: %s", i+1, md.Path)
 				m.log.error(err)
 				continue
 			}
@@ -258,13 +258,13 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 			switch key {
 			case "init":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'init' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'init' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
 				value, err := parseBool(value)
 				if err != nil {
-					err = fmt.Errorf("failed to parse 'init' option value as bool on line %d: %s", i, md.Path)
+					err = fmt.Errorf("failed to parse 'init' option value as bool on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -272,7 +272,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "cpus":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'cpus' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'cpus' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -280,7 +280,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "memory":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'memory' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'memory' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -288,7 +288,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "ulimits":
 				if value != "" {
-					err = fmt.Errorf("inline value provided for 'ulimits' option on line %d (use unordered list): %s", i, md.Path)
+					err = fmt.Errorf("inline value provided for 'ulimits' option on line %d (use unordered list): %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -306,7 +306,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 					}
 					valMatch = optionLineRe.FindStringSubmatch(valLine)
 					if valMatch == nil {
-						err = fmt.Errorf("invalid value provided for 'ulimits' option on line %d: %s", i, md.Path)
+						err = fmt.Errorf("invalid value provided for 'ulimits' option on line %d: %s", i+1, md.Path)
 						m.log.error(err)
 						continue
 					}
@@ -315,13 +315,13 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "pidslimit":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'pidslimit' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'pidslimit' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
 				value, err := strconv.ParseInt(value, 10, 64)
 				if err != nil {
-					err = fmt.Errorf("failed to parse 'pidslimit' option value as int64 on line %d: %s", i, md.Path)
+					err = fmt.Errorf("failed to parse 'pidslimit' option value as int64 on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -329,13 +329,13 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "readonlyrootfs":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'readonlyrootfs' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'readonlyrootfs' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
 				value, err := parseBool(value)
 				if err != nil {
-					err = fmt.Errorf("failed to parse 'readonlyrootfs' option value as bool on line %d: %s", i, md.Path)
+					err = fmt.Errorf("failed to parse 'readonlyrootfs' option value as bool on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -343,7 +343,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "droppedcaps":
 				if value != "" {
-					err = fmt.Errorf("inline value provided for 'droppedcaps' option on line %d (use unordered list): %s", i, md.Path)
+					err = fmt.Errorf("inline value provided for 'droppedcaps' option on line %d (use unordered list): %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -361,7 +361,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 					}
 					valMatch = optionLineRe.FindStringSubmatch(valLine)
 					if valMatch == nil {
-						err = fmt.Errorf("invalid value provided for 'droppedcaps' option on line %d: %s", i, md.Path)
+						err = fmt.Errorf("invalid value provided for 'droppedcaps' option on line %d: %s", i+1, md.Path)
 						m.log.error(err)
 						continue
 					}
@@ -370,13 +370,13 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "nonewprivileges":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'nonewprivileges' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'nonewprivileges' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
 				value, err := parseBool(value)
 				if err != nil {
-					err = fmt.Errorf("failed to parse 'nonewprivileges' option value as bool on line %d: %s", i, md.Path)
+					err = fmt.Errorf("failed to parse 'nonewprivileges' option value as bool on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -384,7 +384,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "storageopts":
 				if value != "" {
-					err = fmt.Errorf("inline value provided for 'storageopts' option on line %d (use unordered list): %s", i, md.Path)
+					err = fmt.Errorf("inline value provided for 'storageopts' option on line %d (use unordered list): %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
@@ -402,7 +402,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 					}
 					valMatch = optionLineRe.FindStringSubmatch(valLine)
 					if valMatch == nil {
-						err = fmt.Errorf("invalid value provided for 'storageopts' option on line %d: %s", i, md.Path)
+						err = fmt.Errorf("invalid value provided for 'storageopts' option on line %d: %s", i+1, md.Path)
 						m.log.error(err)
 						continue
 					}
@@ -411,14 +411,14 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			case "cgroupparent":
 				if value == "" {
-					err = fmt.Errorf("missing value for 'cgroupparent' option on line %d: %s", i, md.Path)
+					err = fmt.Errorf("missing value for 'cgroupparent' option on line %d: %s", i+1, md.Path)
 					m.log.error(err)
 					continue
 				}
 				opts.CgroupParent = value
 				continue
 			default:
-				err = fmt.Errorf("unrecognized container option '%s' on line %d: %s", match[1], i, md.Path)
+				err = fmt.Errorf("unrecognized container option '%s' on line %d: %s", match[1], i+1, md.Path)
 				m.log.error(err)
 				continue
 			}

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -423,6 +423,9 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 				continue
 			}
 		}
+		if md.ContainerOptions == nil {
+			md.ContainerOptions = make(ContainerOptionsWrapper)
+		}
 		md.ContainerOptions[host] = opts
 
 	default:

--- a/cmgr/loader_markdown.go
+++ b/cmgr/loader_markdown.go
@@ -217,7 +217,7 @@ func (m *Manager) processMarkdownSection(md *ChallengeMetadata, section string, 
 			option := strings.ToLower(match[1])
 			switch option {
 			case "internal":
-				value, err := strconv.ParseBool(match[2])
+				value, err := parseBool(match[2])
 				if err != nil {
 					err = fmt.Errorf("unable to parse 'internal' option value on line %d: %s", i, md.Path)
 					m.log.error(err)

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -59,18 +59,12 @@ type NetworkOptions struct {
 	Internal bool `json:"internal"`
 }
 
-type Ulimit struct {
-	Name string  `json:"name"`
-	Soft *uint32 `json:"soft, omitempty"`
-	Hard uint32  `json:"hard"`
-}
-
 type ContainerOptions struct {
 	Init            bool              `json:"init,omitempty"`
-	Cpus            *float32          `json:"cpus,omitempty"`
-	Memory          *uint32           `json:"memory,omitempty"`
-	Ulimits         []Ulimit          `json:"ulimits,omitempty"`
-	PidsLimit       *uint32           `json:"pidslimit",omitempty"`
+	Cpus            *string           `json:"cpus,omitempty"`
+	Memory          *string           `json:"memory,omitempty"`
+	Ulimits         []string          `json:"ulimits,omitempty"`
+	PidsLimit       *int64            `json:"pidslimit",omitempty"`
 	ReadonlyRootfs  bool              `json:"readonlyrootfs,omitempty"`
 	CapDrop         []string          `json:"capdrop,omitempty"`
 	NoNewPrivileges bool              `json:"nonewprivileges,omitempty"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -1,11 +1,8 @@
 package cmgr
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"math/rand"
-	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/jmoiron/sqlx"
@@ -77,35 +74,7 @@ type ContainerOptions struct {
 type ChallengeOptions struct {
 	NetworkOptions   `yaml:",inline"`
 	ContainerOptions `yaml:",inline"`
-	Overrides        ContainerOptionsWrapper `json:"overrides,omitempty" yaml:"overrides"`
-}
-
-// Handle either top-level container options (applies to all containers) or
-// a per-host map for multi-container challenges
-type ContainerOptionsWrapper map[string]ContainerOptions
-
-func (c *ContainerOptionsWrapper) UnmarshalJSON(b []byte) error {
-	if len(b) == 0 {
-		return nil
-	}
-	o := ContainerOptions{}
-	m := make(map[string]ContainerOptions)
-	dec := json.NewDecoder(bytes.NewReader(b))
-	dec.DisallowUnknownFields()
-	err := dec.Decode(&o)
-	if err == nil {
-		m[""] = o
-	} else {
-		if err := json.Unmarshal(b, &m); err != nil {
-			return err
-		}
-	}
-	l := make(map[string]ContainerOptions)
-	for k, v := range m {
-		l[strings.ToLower(k)] = v
-	}
-	*c = l
-	return nil
+	Overrides        map[string]ContainerOptions `json:"overrides,omitempty" yaml:"overrides"`
 }
 
 type ChallengeId string

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -55,26 +55,51 @@ type HostInfo struct {
 	Target string `json:"target,omitempty"`
 }
 
+type NetworkOptions struct {
+	Internal bool `json:"internal"`
+}
+
+type Ulimit struct {
+	Name string  `json:"name"`
+	Soft *uint32 `json:"soft, omitempty"`
+	Hard uint32  `json:"hard"`
+}
+
+type ContainerOptions struct {
+	Init            bool              `json:"init,omitempty"`
+	Cpus            *float32          `json:"cpus,omitempty"`
+	Memory          *uint32           `json:"memory,omitempty"`
+	Ulimits         []Ulimit          `json:"ulimits,omitempty"`
+	PidsLimit       *uint32           `json:"pidslimit",omitempty"`
+	ReadonlyRootfs  bool              `json:"readonlyrootfs,omitempty"`
+	CapDrop         []string          `json:"capdrop,omitempty"`
+	NoNewPrivileges bool              `json:"nonewprivileges,omitempty"`
+	StorageOpt      map[string]string `json:"storageopt,omitempty"`
+	CgroupParent    *string           `json:"cgroupparent,omitempty"`
+}
+
 type ChallengeId string
 type ChallengeMetadata struct {
-	Id               ChallengeId         `json:"id"`
-	Name             string              `json:"name,omitempty"`
-	Namespace        string              `json:"namespace"`
-	ChallengeType    string              `json:"challenge_type"`
-	Description      string              `json:"description,omitempty"`
-	Details          string              `json:"details,omitempty"`
-	Hints            []string            `json:"hints,omitempty"`
-	SourceChecksum   uint32              `json:"source_checksum"`
-	MetadataChecksum uint32              `json:"metadata_checksum`
-	Path             string              `json:"path"`
-	Templatable      bool                `json:"templatable,omitempty"`
-	PortMap          map[string]PortInfo `json:"port_map,omitempty"`
-	Hosts            []HostInfo          `json:"hosts"`
-	MaxUsers         int                 `json:"max_users,omitempty"`
-	Category         string              `json:"category,omitempty"`
-	Points           int                 `json:"points,omitempty"`
-	Tags             []string            `json:"tags,omitempty"`
-	Attributes       map[string]string   `json:"attributes,omitempty"`
+	Id               ChallengeId                 `json:"id"`
+	Name             string                      `json:"name,omitempty"`
+	Namespace        string                      `json:"namespace"`
+	ChallengeType    string                      `json:"challenge_type"`
+	Description      string                      `json:"description,omitempty"`
+	Details          string                      `json:"details,omitempty"`
+	Hints            []string                    `json:"hints,omitempty"`
+	SourceChecksum   uint32                      `json:"source_checksum"`
+	MetadataChecksum uint32                      `json:"metadata_checksum`
+	Path             string                      `json:"path"`
+	Templatable      bool                        `json:"templatable,omitempty"`
+	PortMap          map[string]PortInfo         `json:"port_map,omitempty"`
+	Hosts            []HostInfo                  `json:"hosts"`
+	MaxUsers         int                         `json:"max_users,omitempty"`
+	Category         string                      `json:"category,omitempty"`
+	Points           int                         `json:"points,omitempty"`
+	Tags             []string                    `json:"tags,omitempty"`
+	Attributes       map[string]string           `json:"attributes,omitempty"`
+	NetworkOptions   *NetworkOptions             `json:"network_options,omitempty"`
+	ContainerOptions map[string]ContainerOptions `json:"container_options,omitempty"`
 
 	SolveScript bool             `json:"solve_script,omitempty"`
 	Builds      []*BuildMetadata `json:"builds,omitempty"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -65,7 +65,7 @@ type ContainerOptions struct {
 	Cpus            string            `json:"cpus,omitempty"`
 	Memory          string            `json:"memory,omitempty"`
 	Ulimits         []string          `json:"ulimits,omitempty"`
-	PidsLimit       int64             `json:"pidslimit",omitempty"`
+	PidsLimit       int64             `json:"pidslimit,omitempty"`
 	ReadonlyRootfs  bool              `json:"readonlyrootfs,omitempty"`
 	DroppedCaps     []string          `json:"droppedcaps,omitempty"`
 	NoNewPrivileges bool              `json:"nonewprivileges,omitempty"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -71,7 +71,7 @@ type ContainerOptions struct {
 	ReadonlyRootfs  bool     `json:"readonlyrootfs,omitempty"`
 	DroppedCaps     []string `json:"droppedcaps,omitempty"`
 	NoNewPrivileges bool     `json:"nonewprivileges,omitempty"`
-	StorageOpts     []string `json:"storageopts,omitempty"`
+	DiskQuota       string   `json:"diskquota,omitempty"`
 	CgroupParent    string   `json:"cgroupparent,omitempty"`
 }
 

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -66,9 +66,9 @@ type ContainerOptions struct {
 	Ulimits         []string          `json:"ulimits,omitempty"`
 	PidsLimit       *int64            `json:"pidslimit",omitempty"`
 	ReadonlyRootfs  bool              `json:"readonlyrootfs,omitempty"`
-	CapDrop         []string          `json:"capdrop,omitempty"`
+	DroppedCaps     []string          `json:"droppedcaps,omitempty"`
 	NoNewPrivileges bool              `json:"nonewprivileges,omitempty"`
-	StorageOpt      map[string]string `json:"storageopt,omitempty"`
+	StorageOpts     map[string]string `json:"storageopts,omitempty"`
 	CgroupParent    *string           `json:"cgroupparent,omitempty"`
 }
 

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -113,7 +113,7 @@ type ChallengeMetadata struct {
 	Points           int                     `json:"points,omitempty"`
 	Tags             []string                `json:"tags,omitempty"`
 	Attributes       map[string]string       `json:"attributes,omitempty"`
-	NetworkOptions   *NetworkOptions         `json:"network_options,omitempty"`
+	NetworkOptions   NetworkOptions          `json:"network_options,omitempty"`
 	ContainerOptions ContainerOptionsWrapper `json:"container_options,omitempty"`
 
 	SolveScript bool             `json:"solve_script,omitempty"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -59,9 +59,7 @@ type HostInfo struct {
 	Target string `json:"target,omitempty"`
 }
 
-type NetworkOptions struct {
-	InternalNetwork bool `json:"internal_network" yaml:"internal_network"`
-}
+type NetworkOptions struct{}
 
 type ContainerOptions struct {
 	Init            bool     `json:"init,omitempty"            yaml:"init"`

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"math/rand"
+	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/jmoiron/sqlx"
@@ -89,7 +90,11 @@ func (c *ContainerOptionsWrapper) UnmarshalJSON(b []byte) error {
 		}
 		m[""] = o
 	}
-	*c = m
+	l := make(map[string]ContainerOptions)
+	for k, v := range m {
+		l[strings.ToLower(k)] = v
+	}
+	*c = l
 	return nil
 }
 

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -21,6 +21,7 @@ const (
 	LOGGING_ENV        string = "CMGR_LOGGING"
 	IFACE_ENV          string = "CMGR_INTERFACE"
 	PORTS_ENV          string = "CMGR_PORTS"
+	DISK_QUOTA_ENV     string = "CMGR_ENABLE_DISK_QUOTAS"
 
 	DYNAMIC_INSTANCES int = -1
 	LOCKED            int = -2

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -62,15 +62,15 @@ type NetworkOptions struct {
 
 type ContainerOptions struct {
 	Init            bool              `json:"init,omitempty"`
-	Cpus            *string           `json:"cpus,omitempty"`
-	Memory          *string           `json:"memory,omitempty"`
+	Cpus            string            `json:"cpus,omitempty"`
+	Memory          string            `json:"memory,omitempty"`
 	Ulimits         []string          `json:"ulimits,omitempty"`
-	PidsLimit       *int64            `json:"pidslimit",omitempty"`
+	PidsLimit       int64             `json:"pidslimit",omitempty"`
 	ReadonlyRootfs  bool              `json:"readonlyrootfs,omitempty"`
 	DroppedCaps     []string          `json:"droppedcaps,omitempty"`
 	NoNewPrivileges bool              `json:"nonewprivileges,omitempty"`
 	StorageOpts     map[string]string `json:"storageopts,omitempty"`
-	CgroupParent    *string           `json:"cgroupparent,omitempty"`
+	CgroupParent    string            `json:"cgroupparent,omitempty"`
 }
 
 // Handle either top-level container options (applies to all containers) or

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -1,6 +1,7 @@
 package cmgr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"math/rand"
@@ -82,13 +83,17 @@ func (c *ContainerOptionsWrapper) UnmarshalJSON(b []byte) error {
 	if len(b) == 0 {
 		return nil
 	}
+	o := ContainerOptions{}
 	m := make(map[string]ContainerOptions)
-	if err := json.Unmarshal(b, &m); err != nil {
-		o := ContainerOptions{}
-		if err := json.Unmarshal(b, &o); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&o)
+	if err == nil {
+		m[""] = o
+	} else {
+		if err := json.Unmarshal(b, &m); err != nil {
 			return err
 		}
-		m[""] = o
 	}
 	l := make(map[string]ContainerOptions)
 	for k, v := range m {

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -60,20 +60,26 @@ type HostInfo struct {
 }
 
 type NetworkOptions struct {
-	Internal bool `json:"internal"`
+	InternalNetwork bool `json:"internal_network" yaml:"internal_network"`
 }
 
 type ContainerOptions struct {
-	Init            bool     `json:"init,omitempty"`
-	Cpus            string   `json:"cpus,omitempty"`
-	Memory          string   `json:"memory,omitempty"`
-	Ulimits         []string `json:"ulimits,omitempty"`
-	PidsLimit       int64    `json:"pidslimit,omitempty"`
-	ReadonlyRootfs  bool     `json:"readonlyrootfs,omitempty"`
-	DroppedCaps     []string `json:"droppedcaps,omitempty"`
-	NoNewPrivileges bool     `json:"nonewprivileges,omitempty"`
-	DiskQuota       string   `json:"diskquota,omitempty"`
-	CgroupParent    string   `json:"cgroupparent,omitempty"`
+	Init            bool     `json:"init,omitempty"            yaml:"init"`
+	Cpus            string   `json:"cpus,omitempty"            yaml:"cpus"`
+	Memory          string   `json:"memory,omitempty"          yaml:"memory"`
+	Ulimits         []string `json:"ulimits,omitempty"         yaml:"ulimits"`
+	PidsLimit       int64    `json:"pidslimit,omitempty"       yaml:"pidslimit"`
+	ReadonlyRootfs  bool     `json:"readonlyrootfs,omitempty"  yaml:"readonlyrootfs"`
+	DroppedCaps     []string `json:"droppedcaps,omitempty"     yaml:"droppedcaps"`
+	NoNewPrivileges bool     `json:"nonewprivileges,omitempty" yaml:"nonewprivileges"`
+	DiskQuota       string   `json:"diskquota,omitempty"       yaml:"diskquota"`
+	CgroupParent    string   `json:"cgroupparent,omitempty"    yaml:"cgroupparent"`
+}
+
+type ChallengeOptions struct {
+	NetworkOptions   `yaml:",inline"`
+	ContainerOptions `yaml:",inline"`
+	Overrides        ContainerOptionsWrapper `json:"overrides,omitempty" yaml:"overrides"`
 }
 
 // Handle either top-level container options (applies to all containers) or
@@ -106,26 +112,25 @@ func (c *ContainerOptionsWrapper) UnmarshalJSON(b []byte) error {
 
 type ChallengeId string
 type ChallengeMetadata struct {
-	Id               ChallengeId             `json:"id"`
-	Name             string                  `json:"name,omitempty"`
-	Namespace        string                  `json:"namespace"`
-	ChallengeType    string                  `json:"challenge_type"`
-	Description      string                  `json:"description,omitempty"`
-	Details          string                  `json:"details,omitempty"`
-	Hints            []string                `json:"hints,omitempty"`
-	SourceChecksum   uint32                  `json:"source_checksum"`
-	MetadataChecksum uint32                  `json:"metadata_checksum`
-	Path             string                  `json:"path"`
-	Templatable      bool                    `json:"templatable,omitempty"`
-	PortMap          map[string]PortInfo     `json:"port_map,omitempty"`
-	Hosts            []HostInfo              `json:"hosts"`
-	MaxUsers         int                     `json:"max_users,omitempty"`
-	Category         string                  `json:"category,omitempty"`
-	Points           int                     `json:"points,omitempty"`
-	Tags             []string                `json:"tags,omitempty"`
-	Attributes       map[string]string       `json:"attributes,omitempty"`
-	NetworkOptions   NetworkOptions          `json:"network_options,omitempty"`
-	ContainerOptions ContainerOptionsWrapper `json:"container_options,omitempty"`
+	Id               ChallengeId         `json:"id"`
+	Name             string              `json:"name,omitempty"`
+	Namespace        string              `json:"namespace"`
+	ChallengeType    string              `json:"challenge_type"`
+	Description      string              `json:"description,omitempty"`
+	Details          string              `json:"details,omitempty"`
+	Hints            []string            `json:"hints,omitempty"`
+	SourceChecksum   uint32              `json:"source_checksum"`
+	MetadataChecksum uint32              `json:"metadata_checksum`
+	Path             string              `json:"path"`
+	Templatable      bool                `json:"templatable,omitempty"`
+	PortMap          map[string]PortInfo `json:"port_map,omitempty"`
+	Hosts            []HostInfo          `json:"hosts"`
+	MaxUsers         int                 `json:"max_users,omitempty"`
+	Category         string              `json:"category,omitempty"`
+	Points           int                 `json:"points,omitempty"`
+	Tags             []string            `json:"tags,omitempty"`
+	Attributes       map[string]string   `json:"attributes,omitempty"`
+	ChallengeOptions ChallengeOptions    `json:"challenge_options,omitempty"`
 
 	SolveScript bool             `json:"solve_script,omitempty"`
 	Builds      []*BuildMetadata `json:"builds,omitempty"`
@@ -176,11 +181,11 @@ type InstanceMetadata struct {
 }
 
 type Schema struct {
-	Name       string                             `json:"name" yaml:"name"`
+	Name       string                             `json:"name"        yaml:"name"`
 	FlagFormat string                             `json:"flag_format" yaml:"flag_format"`
-	Challenges map[ChallengeId]BuildSpecification `json:"challenges" yaml:"challenges"`
+	Challenges map[ChallengeId]BuildSpecification `json:"challenges"  yaml:"challenges"`
 }
 type BuildSpecification struct {
-	Seeds         []int `json:"seeds" yaml:"seeds"`
+	Seeds         []int `json:"seeds"          yaml:"seeds"`
 	InstanceCount int   `json:"instance_count" yaml:"instance_count"`
 }

--- a/cmgr/types.go
+++ b/cmgr/types.go
@@ -62,16 +62,16 @@ type NetworkOptions struct {
 }
 
 type ContainerOptions struct {
-	Init            bool              `json:"init,omitempty"`
-	Cpus            string            `json:"cpus,omitempty"`
-	Memory          string            `json:"memory,omitempty"`
-	Ulimits         []string          `json:"ulimits,omitempty"`
-	PidsLimit       int64             `json:"pidslimit,omitempty"`
-	ReadonlyRootfs  bool              `json:"readonlyrootfs,omitempty"`
-	DroppedCaps     []string          `json:"droppedcaps,omitempty"`
-	NoNewPrivileges bool              `json:"nonewprivileges,omitempty"`
-	StorageOpts     map[string]string `json:"storageopts,omitempty"`
-	CgroupParent    string            `json:"cgroupparent,omitempty"`
+	Init            bool     `json:"init,omitempty"`
+	Cpus            string   `json:"cpus,omitempty"`
+	Memory          string   `json:"memory,omitempty"`
+	Ulimits         []string `json:"ulimits,omitempty"`
+	PidsLimit       int64    `json:"pidslimit,omitempty"`
+	ReadonlyRootfs  bool     `json:"readonlyrootfs,omitempty"`
+	DroppedCaps     []string `json:"droppedcaps,omitempty"`
+	NoNewPrivileges bool     `json:"nonewprivileges,omitempty"`
+	StorageOpts     []string `json:"storageopts,omitempty"`
+	CgroupParent    string   `json:"cgroupparent,omitempty"`
 }
 
 // Handle either top-level container options (applies to all containers) or

--- a/examples/markdown_challenges.md
+++ b/examples/markdown_challenges.md
@@ -144,19 +144,22 @@ option to `docker run`. Specify a boolean value, as shown below. Defaults to `fa
 
 - NoNewPrivileges: true
 
-The `StorageOpts` option can be used to pass additional options to the container's storage driver.
-This is equivalent to passing [`--storage-opt`](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container) options to `docker run`.
+The `DiskQuota` option can be used to limit the maximum size of the container's writable layer. This
+is equivalent to passing the [`--storage-opt
+size`](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container)
+option to `docker run`.
 
-**Note that this is potentially dangerous**, as passing an option unsupported by the Docker host's
-storage driver can cause container creation to fail at runtime. This option is intended for advanced
-users only. The primary motivation is to allow specifying a writable layer size limit via the `size=`
-option when using the `overlay2` storage driver and [pquota-enabled](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsquota) XFS backing storage (see this
-[Docker Engine PR](https://github.com/moby/moby/pull/24771) for more details.)
+Note that this option is **only supported** when using the `overlay2` Docker storage driver and
+[pquota-enabled](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsquota)
+XFS backing storage (see this [Docker Engine PR](https://github.com/moby/moby/pull/24771) for more
+details.) If these requirements are not met, container creation will fail at runtime.
 
-Specify a list of options, as shown below. Unset by default.
+To help prevent this issue, the `DiskQuota` option only takes effect if the
+`CMGR_ENABLE_DISK_QUOTAS` environment variable is set.
 
-- StorageOpts:
-  - size=256m
+Specify an integer value with unit, like `256m`. Unset by default.
+
+- DiskQuota: 256m
 
 The `CgroupParent` option can be used to manually specify the cgroup that a container will run in.
 This is equivalent to passing the [`--cgroup-parent`](https://docs.docker.com/engine/reference/run/#specify-custom-cgroups)

--- a/examples/markdown_challenges.md
+++ b/examples/markdown_challenges.md
@@ -92,9 +92,8 @@ containers.
   [here](https://docs.docker.com/engine/reference/commandline/run/#for-nproc-usage) (use the
   `pidslimit` option instead). This is equivalent to passing
   [`--ulimit`](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit)
-  options to `docker run`. **However**, unlike in the Docker CLI, separate soft and hard limits are
-  not supported. Specify a list of limit names and hard limits, as shown in the example below. Unset
-  by default.
+  options to `docker run`. Specify a list of limit names and limits, as shown in the example below.
+  Unset by default.
 
 - The `pidslimit` option specifies the maximum number of simultaneous processes inside the
   container. This is useful in order to prevent forkbombs from crashing the Docker host. This is
@@ -155,7 +154,7 @@ init: true
 cpus: 0.5
 memory: 512m
 ulimits:
-    - nofile=512
+    - nofile=512:1024
     - stack=4096
     - fsize=2048
 pidslimit: 5

--- a/examples/markdown_challenges.md
+++ b/examples/markdown_challenges.md
@@ -52,17 +52,6 @@ an HTML href tag that uses `http_base`.
 - Organization: ACI
 - Created: 2020-06-24
 
-## Network Options
-
-This optional section can be used to configure the Docker network associated
-with each instance of this challenge. The available options are listed below,
-along with example usage.
-
-The `Internal` option disables Internet access, restricting network traffic to
-the instance's containers. This is equivalent to passing the [`--internal`](https://docs.docker.com/engine/reference/commandline/network_create/#network-internal-mode) flag to [`docker network create`](https://docs.docker.com/engine/reference/commandline/network_create/). Specify a boolean value, as shown below. Defaults to `false`.
-
-- Internal: true
-
 ## Container Options
 
 This optional section can be used to apply additional restrictions to containers

--- a/examples/markdown_challenges.md
+++ b/examples/markdown_challenges.md
@@ -52,114 +52,129 @@ an HTML href tag that uses `http_base`.
 - Organization: ACI
 - Created: 2020-06-24
 
-## Container Options
+## Challenge Options
 
-This optional section can be used to apply additional restrictions to containers
-launched as instances of this challenge. The available options are listed below,
-along with example usage.
+This optional section can be used to apply additional restrictions to instances of this challenge
+via a ```` ```yaml```` fenced code block. The available options are listed below, along with an
+example.
 
-For [multi-container](./custom/README.md) challenges, either specify a `Container Options`
-section as usual to apply the same restrictions to all containers, or specify
-different sections for each host (build stage), e.g. `Container Options: work`.
+For [multi-container](./custom/README.md) challenges, by default any specified options apply to all
+containers. However, it is possible to specify separate options for each host (build stage) via an
+`overrides:` key, as seen in [this example](./multi/problem.md). Note that when an override is
+specified, it serves as a fully distinct set of challenge options for that container and will not be
+merged with any specified top-level options.
 
-Container options are never applied to the ["builder"](./custom/README.md) stage or to solver containers.
+Container options are never applied to the ["builder"](./custom/README.md) stage or to solver
+containers.
 
-The `Init` option runs an init process as PID 1 inside the container. This can be useful if your
-challenge process forks, and will ensure that zombie processes are reaped. This is equivalent to
-passing the [`--init`](https://docs.docker.com/engine/reference/run/#specify-an-init-process) flag
-to `docker run`. Specify a boolean value, as shown below. Defaults to `false`.
+- The `init` option runs an init process as PID 1 inside the container. This can be useful if your
+  challenge process forks, and will ensure that zombie processes are reaped. This is equivalent to
+  passing the [`--init`](https://docs.docker.com/engine/reference/run/#specify-an-init-process) flag
+  to `docker run`. Specify a boolean value, as shown in the example below. Defaults to `false`.
 
-- Init: true
+- The `cpus` option specifies a maximum number of CPU cores that a container can utilize at full
+  capacity. This may be useful in order to prevent computationally-heavy challenge instances from
+  dominating the host. This is equivalent to passing the
+  [`--cpus`](https://docs.docker.com/engine/reference/run/#cpu-period-constraint) option to `docker
+  run`. Specify a floating-point value, as shown in the example below. Unset by default.
 
-The `CPUs` option specifies a maximum number of CPU cores that a container can utilize at full
-capacity. This may be useful in order to prevent computationally-heavy challenge instances from
-dominating the host. This is equivalent to passing the [`--cpus`](https://docs.docker.com/engine/reference/run/#cpu-period-constraint)
-option to `docker run`. Specify a floating-point value, as shown below. Unset by default.
+- The `memory` option specifies the maximum amount of memory available to a container. Attempting to
+  exceed this limit at runtime may cause the container to restart, depending on how the challenge
+  process handles allocation failures. This is useful in order to put an upper bound on the memory
+  available to each challenge instance, preventing memory leaks from crashing the Docker host. This
+  is equivalent to passing the
+  [`--memory`](https://docs.docker.com/engine/reference/run/#user-memory-constraints) option to
+  `docker run`. Specify an integer value with unit, as shown in the example below. Unset by default.
 
-- CPUs: 0.5
+- The `ulimits` option can be used to specify various [resource
+  limits](https://access.redhat.com/solutions/61334) inside the container. Note that the `nproc`
+  ulimit is not supported, for reasons described
+  [here](https://docs.docker.com/engine/reference/commandline/run/#for-nproc-usage) (use the
+  `pidslimit` option instead). This is equivalent to passing
+  [`--ulimit`](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit)
+  options to `docker run`. **However**, unlike in the Docker CLI, separate soft and hard limits are
+  not supported. Specify a list of limit names and hard limits, as shown in the example below. Unset
+  by default.
 
-The `Memory` option specifies the maximum amount of memory available to a container. Attempting to
-exceed this limit at runtime may cause the container to restart, depending on how the challenge
-process handles allocation failures. This is useful in order to put an upper bound on the memory
-available to each challenge instance, preventing memory leaks from crashing the Docker host.
-This is equivalent to passing the [`--memory`](https://docs.docker.com/engine/reference/run/#user-memory-constraints)
-option to `docker run`. Specify an integer value with unit, like `128m`. Unset by default.
+- The `pidslimit` option specifies the maximum number of simultaneous processes inside the
+  container. This is useful in order to prevent forkbombs from crashing the Docker host. This is
+  equivalent to passing the
+  [`--pids-limit`](https://docs.docker.com/engine/reference/commandline/run/) option to `docker
+  run`. Specify an integer value, as shown in the example below. Unset by default.
 
-- Memory: 128m
+- The `readonlyrootfs` option can be used to mount the container's root filesystem as read-only. If
+  your challenge does not need to write to disk outside of `/dev/shm`, this is an easy way to
+  improve the security of your challenge containers. This is equivalent to passing the
+  [`--read-only`](https://docs.docker.com/engine/reference/commandline/run/) flag to `docker run`.
+  Specify a boolean value, as shown in the example below. Defaults to `false`.
 
-The `Ulimits` option can be used to specify various [resource limits](https://access.redhat.com/solutions/61334)
-inside the container. Note that the `nproc` ulimit is not supported, for reasons described
-[here](https://docs.docker.com/engine/reference/commandline/run/#for-nproc-usage) (use the `PidsLimit` option instead).
-This is equivalent to passing [`--ulimit`](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit)
-options to `docker run`. **However**, unlike in the Docker CLI, separate soft and hard limits are not supported.
-Specify a list of limit names and hard limits, as shown below. Unset by default.
+- The `droppedcaps` option can be used to drop additional Linux capabilities inside the container
+  beyond Docker's
+  [defaults](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+  This is equivalent to passing
+  [`--cap-drop`](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+  options to `docker run`. Specify a list of uppercase capability names, as shown in the example
+  below. Unset by default.
 
-- Ulimits:
-  - nofile=512
-  - stack=4096
-  - fsize=2048
+- The `nonewprivileges` option can be used to
+  [prevent](https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html) processes inside
+  the container from gaining additional privileges via `execve()` calls (by exploiting setuid
+  binaries, etc). This is equivalent to passing the
+  [`--security-opt="no-new-privileges:true"`](https://docs.docker.com/engine/reference/run/#security-configuration)
+  option to `docker run`. Specify a boolean value, as shown in the example below. Defaults to
+  `false`.
 
-The `PidsLimit` option specifies the maximum number of simultaneous processes inside the container.
-This is useful in order to prevent forkbombs from crashing the Docker host. This is equivalent to
-passing the [`--pids-limit`](https://docs.docker.com/engine/reference/commandline/run/) option to
-`docker run`. Specify an integer value, as shown below. Unset by default.
+- The `diskquota` option can be used to limit the maximum size of the container's writable layer.
+  This is equivalent to passing the [`--storage-opt
+  size`](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container)
+  option to `docker run`.
 
-- PidsLimit: 256
+  Note that this option is **only supported** when using the `overlay2` Docker storage driver and
+  [pquota-enabled](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsquota)
+  XFS backing storage (see this [Docker Engine PR](https://github.com/moby/moby/pull/24771) for more
+  details.) If these requirements are not met, container creation will fail at runtime.
 
-The `ReadonlyRootfs` option can be used to mount the container's root filesystem as read-only. If
-your challenge does not need to write to disk outside of `/dev/shm`, this is an easy way to improve
-the security of your challenge containers. This is equivalent to passing the
-[`--read-only`](https://docs.docker.com/engine/reference/commandline/run/) flag to `docker run`.
-Specify a boolean value, as shown below. Defaults to `false`.
+  To help prevent this issue, the `diskquota` option only takes effect if the
+  `CMGR_ENABLE_DISK_QUOTAS` environment variable is set.
 
-- ReadonlyRootfs: true
+  Specify an integer value with unit, as shown in the example below. Unset by default.
 
-The `DroppedCaps` option can be used to drop additional Linux capabilities inside the container
-beyond Docker's [defaults](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
-This is equivalent to passing [`--cap-drop`](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
-options to `docker run`. Specify a list of uppercase capability names, as shown below. Unset by default.
+- The `cgroupparent` option can be used to manually specify the cgroup that a container will run in.
+  This is equivalent to passing the
+  [`--cgroup-parent`](https://docs.docker.com/engine/reference/run/#specify-custom-cgroups) flag to
+  `docker run`.
 
-- DroppedCaps:
-  - CHOWN
-  - SETPCAP
-  - SETUID
+  Note that it is also possible to set a default parent cgroup for all containers at the [daemon
+  level](https://docs.docker.com/engine/reference/commandline/dockerd/#default-cgroup-parent).
 
-The `NoNewPrivileges` option can be used to
-[prevent](https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html)
-processes inside the container from gaining additional privileges via `execve()` calls
-(by exploiting setuid binaries, etc). This is equivalent to passing the
-[`--security-opt="no-new-privileges:true"`](https://docs.docker.com/engine/reference/run/#security-configuration)
-option to `docker run`. Specify a boolean value, as shown below. Defaults to `false`.
+  Specify a cgroup name, as shown in the example below. Unset by default.
 
-- NoNewPrivileges: true
+```yaml
+# sample challenge options:
+init: true
+cpus: 0.5
+memory: 512m
+ulimits:
+    - nofile=512
+    - stack=4096
+    - fsize=2048
+pidslimit: 5
+readonlyrootfs: true
+droppedcaps:
+    - CHOWN
+    - SETPCAP
+    - SETUID
+nonewprivileges: true
+diskquota: 256m
+cgroupparent: customcgroup.slice
 
-The `DiskQuota` option can be used to limit the maximum size of the container's writable layer. This
-is equivalent to passing the [`--storage-opt
-size`](https://docs.docker.com/engine/reference/commandline/run/#set-storage-driver-options-per-container)
-option to `docker run`.
-
-Note that this option is **only supported** when using the `overlay2` Docker storage driver and
-[pquota-enabled](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/xfsquota)
-XFS backing storage (see this [Docker Engine PR](https://github.com/moby/moby/pull/24771) for more
-details.) If these requirements are not met, container creation will fail at runtime.
-
-To help prevent this issue, the `DiskQuota` option only takes effect if the
-`CMGR_ENABLE_DISK_QUOTAS` environment variable is set.
-
-Specify an integer value with unit, like `256m`. Unset by default.
-
-- DiskQuota: 256m
-
-The `CgroupParent` option can be used to manually specify the cgroup that a container will run in.
-This is equivalent to passing the [`--cgroup-parent`](https://docs.docker.com/engine/reference/run/#specify-custom-cgroups)
-flag to `docker run`.
-
-Note that it is also possible to set a default parent cgroup for all containers at the [daemon
-level](https://docs.docker.com/engine/reference/commandline/dockerd/#default-cgroup-parent).
-
-Specify a cgroup name, as shown below. Unset by default.
-
-- CgroupParent: customcgroup.slice
+# only relevant for multi-container challenges:
+overrides:
+    work:
+        pidslimit: 10
+    randomDnsName:
+        cpus: 0.25
+```
 
 ## Extra Sections
 

--- a/examples/markdown_challenges.md
+++ b/examples/markdown_challenges.md
@@ -162,10 +162,8 @@ The `CgroupParent` option can be used to manually specify the cgroup that a cont
 This is equivalent to passing the [`--cgroup-parent`](https://docs.docker.com/engine/reference/run/#specify-custom-cgroups)
 flag to `docker run`.
 
-**Note that this is potentially dangerous**, as passing a cgroup name that does not exist on the
-Docker host can cause container creation to fail at runtime. This option is intended for advanced
-users. Note that it is also possible to set a default parent cgroup for all containers at the
-[daemon level](https://docs.docker.com/engine/reference/commandline/dockerd/#default-cgroup-parent).
+Note that it is also possible to set a default parent cgroup for all containers at the [daemon
+level](https://docs.docker.com/engine/reference/commandline/dockerd/#default-cgroup-parent).
 
 Specify a cgroup name, as shown below. Unset by default.
 

--- a/examples/multi/Dockerfile
+++ b/examples/multi/Dockerfile
@@ -4,7 +4,8 @@ FROM ubuntu:20.04 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     python3 \
-    ssh
+    ssh \
+    sudo
 
 RUN mkdir /challenge
 COPY finalize.py .
@@ -25,6 +26,7 @@ RUN python3 finalize.py
 FROM ubuntu:20.04 AS work
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
+    python3 \
     ssh \
     sudo
 RUN mkdir -p /run/sshd
@@ -59,7 +61,9 @@ EXPOSE 22
 FROM ubuntu:20.04 AS randomDnsName
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
-    ssh
+    python3 \
+    ssh \
+    sudo
 RUN mkdir -p /run/sshd
 
 RUN useradd -m -s /bin/bash alice

--- a/examples/multi/problem.md
+++ b/examples/multi/problem.md
@@ -40,6 +40,22 @@ By the end of this challenge, competitors should have a basic understanding of
 how to use package managers for privilege escalation and where to look for easy
 pivot points in a Linux environment.
 
+## Challenge Options
+
+```yaml
+internal_network: true
+
+init: true
+cpus: 0.5
+pidslimit: 5
+
+overrides:
+    work:
+        pidslimit: 10
+    randomDnsName:
+        cpus: 0.25
+```
+
 ## Tags
 
 - privesc

--- a/examples/multi/problem.md
+++ b/examples/multi/problem.md
@@ -44,14 +44,14 @@ pivot points in a Linux environment.
 
 ```yaml
 init: true
-cpus: 0.5
-pidslimit: 5
+cpus: 0.25
+pidslimit: 50
 
 overrides:
     work:
-        pidslimit: 10
-    randomDnsName:
-        cpus: 0.25
+        init: true
+        cpus: 0.5
+        pidslimit: 50
 ```
 
 ## Tags

--- a/examples/multi/problem.md
+++ b/examples/multi/problem.md
@@ -43,8 +43,6 @@ pivot points in a Linux environment.
 ## Challenge Options
 
 ```yaml
-internal_network: true
-
 init: true
 cpus: 0.5
 pidslimit: 5

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.16
 require (
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/containerd/containerd v1.5.7 // indirect
+	github.com/docker/cli v20.10.10+incompatible // indirect
 	github.com/docker/docker v20.10.10+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/yuin/goldmark v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/containerd/containerd v1.5.7 // indirect
-	github.com/docker/cli v20.10.10+incompatible // indirect
+	github.com/docker/cli v20.10.10+incompatible
 	github.com/docker/docker v20.10.10+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/yuin/goldmark v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
+github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=


### PR DESCRIPTION
Adds the ability to set certain options for instance networks and containers. (Deferring to the markdown_challenges.md documentation for more details about the options and how to set them.)

Some more specific technical changes:

- Adds new `networkOptions` and `containerOptions` database tables
- List-based container options get serialized to JSON for storage in the DB, there is a separate `dbContainerOptions` struct that represents this, with `string`s in place of `[]string`s
- When loading challenge definitions from JSON, you should be able to use either a top-level `container_options` object, or a container hostname map (`ContainerOptionsWrapper`). This approximates the `Container Options` vs. `Container Options: <host>` Markdown behavior
- `startNetwork()` and `startContainers()` now take `NetworkOptions` and `map[string]ContainerOptions`, respectively, as additional parameters
  - The latter is a map of hostname/build stage to container options, for multi-container challenges. The empty string represents default (non-host-specific) container options
- A change to network or container options causes a rebuild instead of a refresh
- Instance networks are also recreated along with containers during rebuilds (to account for potential changes to network options)
 
Also, apologies in advance for the messy commit history and any bad decisions (somewhat new to writing Go)
