### PR TITLE
Pin Flask version so that container runs

### DIFF
--- a/cmgr/dockerfiles/flask.Dockerfile
+++ b/cmgr/dockerfiles/flask.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential \
     python3-pip
-RUN pip3 install flask
+RUN pip3 install flask==2.2.5
 RUN groupadd -r flask && useradd -r -d /app -g flask flask
 
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/examples/custom/Dockerfile
+++ b/examples/custom/Dockerfile
@@ -18,7 +18,6 @@ RUN echo $FLAG | openssl aes-256-cbc -k unguessable -pbkdf2 -out secret.enc
 # These "artifacts" are available to competitors for download
 RUN tar czvf /challenge/artifacts.tar.gz secret.enc time.txt
 
-CMD socat TCP4-LISTEN:4242,reuseaddr,fork exec:'echo -n openssl aes-256-cbc -d -k unguessable -pbkdf2 -in secret.enc'
+CMD socat TCP4-LISTEN:4200,reuseaddr,fork exec:'echo -n openssl aes-256-cbc -d -k unguessable -pbkdf2 -in secret.enc'
 
 EXPOSE 4200
-# PUBLISH 4200 AS socat

--- a/examples/custom/solver/solve.py
+++ b/examples/custom/solver/solve.py
@@ -3,7 +3,7 @@ import socket
 import subprocess
 
 c = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-c.connect(("challenge", 4242))
+c.connect(("challenge", 4200))
 command = c.recv(4096).decode()
 
 results = subprocess.run(command, capture_output=True, shell=True, text=True)


### PR DESCRIPTION
This is not an ideal fix - the better option would be to upgrade the code so that it works with more recent versions of Flask. But since it's not clear anyone actually uses or cares about this project, this quick-fix at least makes the historical examples run okay.